### PR TITLE
PR2: prepare decoupled logic (no DOM access) — sunMath + rules

### DIFF
--- a/src/logic/rules.js
+++ b/src/logic/rules.js
@@ -1,0 +1,55 @@
+// src/logic/rules.js
+// Règles "métier": point d'entrée de calculs, SANS accès direct au DOM.
+
+import { DEG2RAD, RAD2DEG, toCartesian, solarAltAz, airMassKY } from "./sunMath.js";
+
+/**
+ * Calcule la position/infos solaires pour une configuration donnée.
+ * NE LIT PAS le DOM : tout est passé en paramètres.
+ */
+export function calculateSolarPosition(params) {
+  const {
+    dayOfYear,          // 1..365
+    localTimeHours,     // ex: 13.5 pour 13h30
+    latDeg, lonDeg,     // latitude/longitude
+    buildingOrientationDeg = 0, // orientation maison
+    radius = 10         // rayon "scène" pour placement
+  } = params;
+
+  // 1) Altitude/Azimuth (remplacera le stub par tes formules lors de l’extraction)
+  const { altitudeDeg, azimuthDeg } = solarAltAz({
+    latDeg, lonDeg, dayOfYear, localTimeHours, buildingOrientationDeg
+  });
+
+  // 2) Coordonnées 3D utiles pour la scène
+  const xyz = toCartesian({
+    r: radius,
+    thetaRad: azimuthDeg * DEG2RAD,
+    phiRad: altitudeDeg * DEG2RAD
+  });
+
+  // 3) Quelques indicateurs (ex: masse d’air)
+  const airMass = airMassKY(altitudeDeg);
+
+  return {
+    altitudeDeg,
+    azimuthDeg,
+    xyz,        // {x,y,z}
+    airMass
+  };
+}
+
+/**
+ * Ex: calculer quelques "événements clés" (lever/zenith/coucher) pour la journée donnée.
+ * Placeholder: on remplira avec tes vraies méthodes au moment de la migration.
+ */
+export function computeSunEvents({ dayOfYear, latDeg, lonDeg, buildingOrientationDeg = 0 }) {
+  return [
+    { label: "Sunrise",   localTimeHours: 6.5  },
+    { label: "Noon",      localTimeHours: 12.0 },
+    { label: "Sunset",    localTimeHours: 19.5 }
+  ].map(e => ({
+    ...e,
+    ...calculateSolarPosition({ dayOfYear, latDeg, lonDeg, buildingOrientationDeg, localTimeHours: e.localTimeHours })
+  }));
+}

--- a/src/logic/sunMath.js
+++ b/src/logic/sunMath.js
@@ -1,0 +1,51 @@
+// src/logic/sunMath.js
+// Utilitaires numériques et solaires (PRÉPARATION — on branchera plus tard)
+
+export const DEG2RAD = Math.PI / 180;
+export const RAD2DEG = 180 / Math.PI;
+
+export function clamp(x, min, max) { return Math.min(max, Math.max(min, x)); }
+
+// ---- Conversions géométriques de base ----
+export function toCartesian({ r, thetaRad, phiRad }) {
+  // theta: azimuth (0=N, est=90°), phi: altitude
+  const x = r * Math.cos(phiRad) * Math.sin(thetaRad);
+  const y = r * Math.sin(phiRad);
+  const z = r * Math.cos(phiRad) * Math.cos(thetaRad);
+  return { x, y, z };
+}
+
+// ---- Astronomie simplifiée (placeholders à compléter lors de l’extraction) ----
+// Ces fonctions seront remplies avec TES formules actuelles (déclinaison, EoT, etc.)
+// quand on migrera depuis le gros HTML.
+export function solarDeclination(dayOfYear) {
+  // TODO: remplacer par ta formule existante
+  // ex. approx: 23.44° * sin(2π * (284+N) / 365)
+  return 23.44 * Math.sin(((2 * Math.PI) * (284 + dayOfYear)) / 365);
+}
+
+export function equationOfTime(dayOfYear) {
+  // TODO: remplacer par ta formule existante (minutes)
+  return 0; 
+}
+
+export function hourAngle(localSolarTimeHours) {
+  // 15° par heure; 12h => 0°
+  return (localSolarTimeHours - 12) * 15;
+}
+
+export function solarAltAz({ latDeg, lonDeg, dayOfYear, localTimeHours, buildingOrientationDeg = 0 }) {
+  // TODO: lire EoT, décalage LST, déclinaison, etc. et renvoyer { altitudeDeg, azimuthDeg }
+  // Placeholder très simple (sera remplacé par ton calcul réel)
+  const alt = clamp(60 - Math.abs(12 - localTimeHours) * 10, 0, 75);
+  const az  = (localTimeHours / 24) * 360; // faux pour l’instant, juste un stub
+  return { altitudeDeg: alt, azimuthDeg: az + buildingOrientationDeg };
+}
+
+// Transmittance atmosphérique type (placeholder)
+export function airMassKY(altitudeDeg) {
+  // TODO: remplacer par ta version
+  const altRad = altitudeDeg * DEG2RAD;
+  const m = 1 / Math.max(0.1, Math.sin(altRad));
+  return clamp(m, 1, 10);
+}


### PR DESCRIPTION
- Add src/logic/sunMath.js: numeric & solar helpers (placeholders to be filled from legacy)
- Add src/logic/rules.js: calculateSolarPosition(params), computeSunEvents(...)
- Update src/main.js to import (no behavior change yet)
- Goal: have pure functions (no DOM) ready to replace inline logic in next PR
