### PR TITLE
Add solar snapshot npm script and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,21 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+
+jobs:
+  solar-snapshots:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - name: Run solar snapshot checks
+        run: npm run test:snapshots

--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@ The tool displays the solar trajectory and helps visualize sunlight at different
 - Observer la position du soleil et son impact sur l’ensoleillement de la maison.
 
 ## 🧪 Vérification des calculs solaires
-- Lancer `node tests/solarEngine.snapshots.mjs` pour comparer le moteur modulaire
+- Lancer `npm run test:snapshots` pour comparer le moteur modulaire
   avec les formules historiques (36 combinaisons jour/heure/latitude + événements clés).
+- Ce script doit absolument réussir **avant toute Pull Request** afin de garder le moteur
+  solaire sous contrôle et éviter toute dérive numérique.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "heliotrack",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "test:snapshots": "node tests/solarEngine.snapshots.mjs"
+  }
+}


### PR DESCRIPTION
## Summary
- add a minimal Node.js package manifest with an npm script for the solar snapshot tests
- document the snapshot test workflow and PR requirement in the README
- add a GitHub Actions workflow that runs the snapshot tests on pushes and pull requests

## Testing
- npm run test:snapshots

------
https://chatgpt.com/codex/tasks/task_e_68c9cc2c030083228273f6a8e1a439ee