### PR TITLE
Improve responsive panels and viewer sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,25 @@ The tool displays the solar trajectory and helps visualize sunlight at different
 ---
 
 ## 🚀 Utilisation / Usage
-- Ouvrir le fichier `index.html` dans un navigateur web.  
-- Sélectionner un jour de l’année pour afficher la trajectoire correspondante.  
+- Ouvrir le fichier `index.html` dans un navigateur web.
+- Sélectionner un jour de l’année pour afficher la trajectoire correspondante.
 - Observer la position du soleil et son impact sur l’ensoleillement de la maison.
+
+## 🧪 Vérification des calculs solaires
+- Lancer `node tests/solarEngine.snapshots.mjs` pour comparer le moteur modulaire
+  avec les formules historiques (36 combinaisons jour/heure/latitude + événements clés).
+
+## 🧰 Développement
+- Le layout “trois panneaux” (`assets/styles.css`) s’adapte désormais aux écrans moyens :
+  la colonne droite passe en tiroir sous 1200 px et reste accessible via le bouton “📊 Onglets”.
+- Les modules `src/view3d/viewer.js` et `src/ui/rightPanel.js` utilisent un `ResizeObserver`
+  et un store pub/sub (`src/state/store.js`) pour réagir aux changements sans accès direct au DOM legacy.
 
 ---
 
 ## 📂 Structure prévue du projet
-- `index.html` → page principale du simulateur  
-- `src/` → fichiers JavaScript et modules  
+- `index.html` → page principale du simulateur
+- `src/` → fichiers JavaScript et modules
 - `assets/` → styles, images, données statiques  
 
 ---

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,16 +1,445 @@
-html, body, #app { height: 100%; margin: 0; }
+:root {
+  color-scheme: light;
+}
+
+html,
+body,
+#app {
+  height: 100%;
+  margin: 0;
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  color: #1f2933;
+  background: #f5f7fb;
+}
+
 .grid {
   display: grid;
-  grid-template-columns: 280px 1fr 360px; /* gauche / centre / droite */
+  grid-template-columns: clamp(220px, 18vw, 260px) minmax(0, 1fr) clamp(300px, 24vw, 360px);
   grid-template-rows: 100%;
   grid-template-areas: "left center right";
-  height: 100%;
+  min-height: 100%;
 }
-.panel-left  { grid-area: left;  overflow: auto; background: #fafafa; border-right: 1px solid #eee; }
-.panel-center{ grid-area: center; display: grid; grid-template-rows: auto 1fr; }
-.panel-right { grid-area: right; overflow: auto; background: #fafafa; border-left: 1px solid #eee; }
-#toolbar { padding: .5rem 1rem; border-bottom: 1px solid #eee; }
-#legacy-app { display: block; }
+
+.panel-left {
+  grid-area: left;
+  overflow-y: auto;
+  background: #fafafa;
+  border-right: 1px solid #e5e7eb;
+  padding: 16px;
+}
+
+.panel-center {
+  grid-area: center;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  background: #fff;
+  min-width: 0;
+}
+
+.panel-right {
+  grid-area: right;
+  display: block;
+  overflow-y: auto;
+  background: #fafafa;
+  border-left: 1px solid #e5e7eb;
+  padding: 16px;
+  min-width: 0;
+  position: relative;
+  transition: transform 0.3s ease;
+}
+
+.left-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.right-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.panel {
+  background: #fff;
+  border-radius: 12px;
+  padding: 12px 14px;
+  box-shadow: 0 2px 10px rgba(15, 23, 42, 0.06);
+}
+
+.panel h3 {
+  margin: 0 0 8px;
+  font-size: 16px;
+}
+
+.panel-compact h3 {
+  margin-bottom: 6px;
+}
+
+.preset-buttons {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.preset-btn {
+  border: 1px solid #d1d5db;
+  background: #fff;
+  border-radius: 8px;
+  padding: 8px 10px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.preset-btn:hover {
+  background: #f3f4f6;
+  box-shadow: inset 0 0 0 1px #cbd5f5;
+}
+
+.slider-label-legend {
+  display: block;
+  font-size: 13px;
+  margin-bottom: 4px;
+  color: #4b5563;
+}
+
+.slider-label {
+  display: flex;
+  justify-content: space-between;
+  font-size: 12px;
+  color: #6b7280;
+  margin-top: 6px;
+}
+
+input[type="range"] {
+  width: 100%;
+  -webkit-appearance: none;
+  height: 8px;
+  border-radius: 4px;
+  background: #e5e7eb;
+  outline: none;
+}
+
+input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ff6b35;
+  cursor: pointer;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+input[type="range"]::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ff6b35;
+  cursor: pointer;
+  border: none;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  padding: 0.5rem 1rem;
+  border-bottom: 1px solid #e5e7eb;
+  background: #fff;
+}
+
+.toolbar-group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.toolbar-title {
+  font-weight: 600;
+  font-size: 13px;
+  color: #4b5563;
+}
+
+.toolbar-btn {
+  border: 1px solid #d1d5db;
+  background: #f9fafb;
+  border-radius: 8px;
+  padding: 6px 10px;
+  cursor: pointer;
+  font-size: 13px;
+  transition: background 0.2s, transform 0.2s, box-shadow 0.2s;
+}
+
+.toolbar-btn:hover {
+  background: #e5f0ff;
+  transform: translateY(-1px);
+}
+
+.toolbar-btn.is-active {
+  background: #2563eb;
+  color: #fff;
+  border-color: #2563eb;
+  box-shadow: 0 4px 12px rgba(37, 99, 235, 0.25);
+}
+
+.toolbar-info {
+  margin-left: auto;
+}
+
+.toolbar-mobile-only {
+  display: none;
+  margin-left: auto;
+}
+
+.viewer-host {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  background: linear-gradient(180deg, #87ceeb 0%, #98d8e8 50%, #deb887 100%);
+  min-height: 0;
+}
+
+.seasonal-legend {
+  position: absolute;
+  left: 12px;
+  bottom: 12px;
+  background: rgba(255, 255, 255, 0.92);
+  padding: 8px 10px;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.15);
+  font-size: 12px;
+  max-width: 220px;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 4px;
+}
+
+.legend-item:last-child {
+  margin-bottom: 0;
+}
+
+.legend-color {
+  width: 12px;
+  height: 3px;
+  border-radius: 2px;
+}
+
+.hint-pan {
+  position: absolute;
+  right: 12px;
+  bottom: 12px;
+  background: rgba(17, 24, 39, 0.7);
+  color: #fff;
+  padding: 6px 8px;
+  border-radius: 8px;
+  font-size: 12px;
+  backdrop-filter: saturate(120%) blur(2px);
+}
+
+.smoke-test {
+  position: absolute;
+  top: 15px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(16, 185, 129, 0.85);
+  color: #fff;
+  padding: 6px 10px;
+  border-radius: 6px;
+  font-size: 12px;
+  z-index: 20;
+  display: none;
+}
+
+.smoke-test.error {
+  background: rgba(239, 68, 68, 0.85);
+}
+
+.results-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.res-item {
+  background: #f8f9fb;
+  border-radius: 10px;
+  padding: 10px;
+}
+
+.res-label {
+  font-size: 12px;
+  color: #6b7280;
+  margin-bottom: 4px;
+  white-space: nowrap;
+}
+
+.res-value {
+  font-size: 18px;
+  font-weight: 600;
+  color: #111827;
+  overflow-wrap: anywhere;
+}
+
+.tabs-nav {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+
+.tab-btn {
+  border: 1px solid #d1d5db;
+  background: #f3f4f6;
+  border-radius: 999px;
+  padding: 6px 14px;
+  cursor: pointer;
+  font-size: 13px;
+  transition: background 0.2s;
+}
+
+.tab-btn.active {
+  background: #2563eb;
+  color: #fff;
+  border-color: #2563eb;
+}
+
+.tabs-content {
+  position: relative;
+}
+
+.tab-panel {
+  display: none;
+}
+
+.tab-panel.active {
+  display: block;
+}
+
+.form-field,
+.form-field-inline,
+.form-field-checkbox {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 12px;
+}
+
+.form-field-checkbox {
+  flex-direction: row;
+  align-items: center;
+}
+
+.form-field label,
+.form-field-inline label {
+  font-size: 13px;
+  color: #374151;
+}
+
+.form-field input,
+.form-field-inline input {
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  padding: 8px;
+  font-size: 14px;
+}
+
+.form-field small {
+  color: #6b7280;
+  font-size: 12px;
+}
+
+.panel-right-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  backdrop-filter: blur(2px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+  z-index: 30;
+}
+
+.panel-right-backdrop.active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+@media (max-width: 1440px) {
+  .grid {
+    grid-template-columns: clamp(200px, 20vw, 240px) minmax(0, 1fr) clamp(260px, 26vw, 330px);
+  }
+}
+
+@media (max-width: 1280px) {
+  .grid {
+    grid-template-columns: clamp(190px, 22vw, 230px) minmax(0, 1fr) clamp(240px, 32vw, 310px);
+  }
+}
+
 @media (max-width: 1200px) {
-  .grid { grid-template-columns: 56px 1fr 0; } /* collapse left, hide right */
+  .grid {
+    grid-template-columns: clamp(56px, 18vw, 210px) minmax(0, 1fr) 0;
+  }
+
+  .panel-right {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: min(360px, 90vw);
+    border-left: none;
+    border-radius: 16px 0 0 16px;
+    box-shadow: -4px 0 16px rgba(15, 23, 42, 0.28);
+    padding: 20px 18px 24px;
+    transform: translateX(100%);
+    z-index: 40;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .panel-right.open {
+    transform: translateX(0);
+  }
+
+  .toolbar-mobile-only {
+    display: flex;
+    align-items: center;
+  }
+
+  .toolbar-info {
+    order: 3;
+    width: 100%;
+    justify-content: space-between;
+  }
+}
+
+@media (max-width: 900px) {
+  .grid {
+    grid-template-columns: 0 1fr 0;
+  }
+
+  .panel-left {
+    display: none;
+  }
+
+  .toolbar {
+    gap: 12px;
+  }
+
+  .toolbar-group {
+    flex-wrap: wrap;
+  }
+}
+
+@media (min-width: 1201px) {
+  .panel-right-backdrop {
+    display: none;
+  }
 }

--- a/index.html
+++ b/index.html
@@ -11,13 +11,11 @@
       <aside id="left" class="panel-left"></aside>
       <main id="center" class="panel-center">
         <div id="toolbar"></div>
-        <!-- Temp: on garde le site actuel via iframe pour ne RIEN casser -->
-        <iframe id="legacy-app" src="./app-legacy.html" title="HelioTrack" style="border:0;width:100%;height:100%"></iframe>
       </main>
       <aside id="right" class="panel-right"></aside>
     </div>
 
-    <!-- Prépare l’architecture, pas encore branchée -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script type="module" src="./src/main.js"></script>
   </body>
 </html>

--- a/src/logic/rules.js
+++ b/src/logic/rules.js
@@ -1,7 +1,19 @@
 // src/logic/rules.js
 // Règles "métier": point d'entrée de calculs, SANS accès direct au DOM.
 
-import { DEG2RAD, RAD2DEG, toCartesian, solarAltAz, airMassKY } from "./sunMath.js";
+import {
+  DEG2RAD,
+  toCartesian,
+  solarAltAz,
+  airMassKY,
+  earthSunDistanceAu,
+  SOLAR_CONSTANT
+} from "./sunMath.js";
+
+function minimalAzimuthDifference(angleDeg) {
+  const wrapped = ((angleDeg % 360) + 360) % 360;
+  return wrapped > 180 ? 360 - wrapped : wrapped;
+}
 
 /**
  * Calcule la position/infos solaires pour une configuration donnée.
@@ -16,40 +28,113 @@ export function calculateSolarPosition(params) {
     radius = 10         // rayon "scène" pour placement
   } = params;
 
-  // 1) Altitude/Azimuth (remplacera le stub par tes formules lors de l’extraction)
-  const { altitudeDeg, azimuthDeg } = solarAltAz({
-    latDeg, lonDeg, dayOfYear, localTimeHours, buildingOrientationDeg
+  const geometry = solarAltAz({
+    latDeg,
+    lonDeg,
+    dayOfYear,
+    localTimeHours,
+    buildingOrientationDeg
   });
 
-  // 2) Coordonnées 3D utiles pour la scène
+  const {
+    altitudeDeg,
+    azimuthDeg,
+    azimuthFromOrientationDeg,
+    declinationDeg,
+    equationOfTimeMinutes,
+    localSolarTimeHours,
+    hourAngleDeg
+  } = geometry;
+
   const xyz = toCartesian({
     r: radius,
     thetaRad: azimuthDeg * DEG2RAD,
     phiRad: altitudeDeg * DEG2RAD
   });
 
-  // 3) Quelques indicateurs (ex: masse d’air)
   const airMass = airMassKY(altitudeDeg);
+  const earthSunDistance = earthSunDistanceAu(dayOfYear);
+  const incidenceAngleDeg = minimalAzimuthDifference(azimuthFromOrientationDeg);
+
+  let directIrradiance = 0;
+  if (altitudeDeg > 0 && incidenceAngleDeg < 90) {
+    const effectiveAirMass = Math.min(airMass, 38);
+    const atmosphericAttenuation = Math.pow(0.7, Math.pow(effectiveAirMass, 0.678));
+    const cosIncidence = Math.cos(incidenceAngleDeg * DEG2RAD);
+    directIrradiance = (SOLAR_CONSTANT * atmosphericAttenuation * cosIncidence) /
+      (earthSunDistance * earthSunDistance);
+  }
 
   return {
     altitudeDeg,
+    elevation: altitudeDeg,
     azimuthDeg,
-    xyz,        // {x,y,z}
-    airMass
+    azimuth: azimuthDeg,
+    azimuthFromOrientationDeg,
+    declinationDeg,
+    declination: declinationDeg,
+    equationOfTimeMinutes,
+    localSolarTimeHours,
+    hourAngleDeg,
+    hourAngle: hourAngleDeg,
+    earthSunDistance,
+    airMass,
+    directIrradiance,
+    incidenceAngleDeg,
+    incidenceAngle: incidenceAngleDeg,
+    isAboveHorizon: altitudeDeg > 0,
+    xyz
   };
 }
 
 /**
- * Ex: calculer quelques "événements clés" (lever/zenith/coucher) pour la journée donnée.
- * Placeholder: on remplira avec tes vraies méthodes au moment de la migration.
+ * Calcul de quelques événements solaires (lever, midi solaire, coucher).
  */
-export function computeSunEvents({ dayOfYear, latDeg, lonDeg, buildingOrientationDeg = 0 }) {
-  return [
-    { label: "Sunrise",   localTimeHours: 6.5  },
-    { label: "Noon",      localTimeHours: 12.0 },
-    { label: "Sunset",    localTimeHours: 19.5 }
-  ].map(e => ({
-    ...e,
-    ...calculateSolarPosition({ dayOfYear, latDeg, lonDeg, buildingOrientationDeg, localTimeHours: e.localTimeHours })
-  }));
+export function computeSunEvents({
+  dayOfYear,
+  latDeg,
+  lonDeg,
+  buildingOrientationDeg = 0,
+  stepHours = 0.25
+}) {
+  let prevElevation = null;
+  let prevTime = null;
+  let sunrise = NaN;
+  let sunset = NaN;
+  let maxAltitude = -Infinity;
+  let solarNoon = NaN;
+
+  for (let t = 0; t <= 24 + 1e-9; t += stepHours) {
+    const pos = calculateSolarPosition({
+      dayOfYear,
+      latDeg,
+      lonDeg,
+      buildingOrientationDeg,
+      localTimeHours: t
+    });
+
+    const elev = pos.altitudeDeg;
+    if (elev > maxAltitude) {
+      maxAltitude = elev;
+      solarNoon = t;
+    }
+
+    if (prevElevation !== null) {
+      const crossing = (prevElevation <= 0 && elev > 0) || (prevElevation >= 0 && elev < 0);
+      if (crossing) {
+        const frac = prevElevation === elev ? 0 : (0 - prevElevation) / (elev - prevElevation);
+        const timeCross = prevTime + frac * (t - prevTime);
+        if (elev > prevElevation && Number.isNaN(sunrise)) {
+          sunrise = timeCross;
+        } else if (elev < prevElevation) {
+          sunset = timeCross;
+        }
+      }
+    }
+
+    prevElevation = elev;
+    prevTime = t;
+  }
+
+  return { sunrise, sunset, solarNoon, maxAltitude };
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,10 +1,186 @@
 import { store } from "./state/store.js";
-import { calculateSolarPosition } from "./logic/rules.js";
+import { calculateSolarPosition, computeSunEvents } from "./logic/rules.js";
+import { createViewer } from "./view3d/viewer.js";
+import { attachOrbitControls, setViewPreset, updateOrbitInfo } from "./view3d/controls3d.js";
+import { initLeftPanel } from "./ui/leftPanel.js";
+import { initRightPanel } from "./ui/rightPanel.js";
+import { initToolbar } from "./ui/toolbar.js";
+import { initSmoke } from "./ui/smoke.js";
 
-store.subscribe((_chg, snapshot) => {
-  // Bientôt: applyRules(snapshot), update3D(snapshot), updateCharts(snapshot)
+const initialState = {
+  latDeg: 48.8566,
+  lonDeg: 2.3522,
+  dayOfYear: 80,
+  localTimeHours: 12,
+  buildingOrientationDeg: 180,
+  timezoneOffsetHours: 0,
+  useCivilTime: false,
+};
+Object.entries(initialState).forEach(([key, value]) => store.set(key, value));
+
+const leftMount = document.getElementById("left");
+const rightMount = document.getElementById("right");
+const center = document.getElementById("center");
+const toolbarMount = document.getElementById("toolbar");
+
+const viewerHost = document.createElement("div");
+viewerHost.className = "viewer-host";
+center.appendChild(viewerHost);
+
+const smoke = initSmoke({ mount: viewerHost });
+
+const viewer = createViewer({
+  container: viewerHost,
+  initialLatitude: store.get("latDeg"),
+  initialOrientationDeg: store.get("buildingOrientationDeg"),
 });
 
-console.log("[HelioTrack] PR2 prep ready. Example call:", 
-  calculateSolarPosition({ dayOfYear: 172, localTimeHours: 12, latDeg: 45.76, lonDeg: 4.83, buildingOrientationDeg: 0 })
-);
+smoke.run("Initialisation conteneur", () => !!viewerHost);
+smoke.run("Three.js prêt", () => !!viewer?.renderer?.domElement);
+
+let toolbarApi = null;
+let rightPanelApi = null;
+const controls = attachOrbitControls({
+  camera: viewer.camera,
+  domElement: viewer.renderer.domElement,
+  onChange: () => {
+    const info = updateOrbitInfo({ camera: viewer.camera });
+    toolbarApi?.setOrbitInfo(info.text);
+  },
+});
+
+function refreshOrbitInfo() {
+  const info = updateOrbitInfo({ camera: viewer.camera });
+  toolbarApi?.setOrbitInfo(info.text);
+}
+
+function handlePresetChange(preset) {
+  setViewPreset({ camera: viewer.camera, preset, onChange: refreshOrbitInfo });
+  controls.sync();
+}
+
+let animationMode = "idle";
+let animationTimer = null;
+
+function clearAnimationTimer() {
+  if (animationTimer !== null) {
+    clearTimeout(animationTimer);
+    animationTimer = null;
+  }
+}
+
+function stopAnimation() {
+  animationMode = "idle";
+  clearAnimationTimer();
+}
+
+function startDayAnimation() {
+  stopAnimation();
+  animationMode = "day";
+  let hour = 6;
+  const step = () => {
+    if (animationMode !== "day") return;
+    store.set("localTimeHours", Math.round(hour * 10) / 10);
+    hour += 0.2;
+    if (hour <= 18.0001) {
+      animationTimer = setTimeout(() => requestAnimationFrame(step), 100);
+    } else {
+      stopAnimation();
+    }
+  };
+  step();
+}
+
+function startYearAnimation() {
+  stopAnimation();
+  animationMode = "year";
+  let day = 1;
+  const step = () => {
+    if (animationMode !== "year") return;
+    store.set("dayOfYear", Math.round(day));
+    day += 2;
+    if (day <= 365.5) {
+      animationTimer = setTimeout(() => requestAnimationFrame(step), 50);
+    } else {
+      stopAnimation();
+    }
+  };
+  step();
+}
+
+function handleAnimationCommand(command) {
+  if (command === "day") startDayAnimation();
+  else if (command === "year") startYearAnimation();
+  else stopAnimation();
+}
+
+toolbarApi = initToolbar({
+  mount: toolbarMount,
+  onPresetChange: handlePresetChange,
+  onAnimationCommand: handleAnimationCommand,
+  onToggleRightPanel: () => rightPanelApi?.toggle(),
+});
+refreshOrbitInfo();
+
+initLeftPanel({
+  mount: leftMount,
+  store,
+  onManualChange: () => stopAnimation(),
+});
+
+rightPanelApi = initRightPanel({
+  mount: rightMount,
+  store,
+  onOpenChange: (isOpen) => toolbarApi?.setRightPanelOpen(isOpen),
+});
+toolbarApi?.setRightPanelOpen(false);
+const rightPanel = rightPanelApi;
+
+window.addEventListener("resize", () => viewer.resize());
+
+let lastLatitude = store.get("latDeg");
+
+function applyState(snapshot) {
+  const requiredKeys = ["dayOfYear", "localTimeHours", "latDeg", "lonDeg", "buildingOrientationDeg"];
+  const missing = requiredKeys.some((key) => snapshot[key] === undefined);
+  if (missing) return;
+
+  const solar = calculateSolarPosition({
+    dayOfYear: snapshot.dayOfYear,
+    localTimeHours: snapshot.localTimeHours,
+    latDeg: snapshot.latDeg,
+    lonDeg: snapshot.lonDeg,
+    buildingOrientationDeg: snapshot.buildingOrientationDeg,
+  });
+
+  viewer.updateSunPosition(solar);
+  viewer.updateBuildingOrientation(snapshot.buildingOrientationDeg);
+  rightPanel.updateResults(solar);
+
+  if (snapshot.latDeg !== lastLatitude) {
+    viewer.updateSeasonalPaths(snapshot.latDeg);
+    lastLatitude = snapshot.latDeg;
+  }
+
+  const events = computeSunEvents({
+    dayOfYear: snapshot.dayOfYear,
+    latDeg: snapshot.latDeg,
+    lonDeg: snapshot.lonDeg,
+    buildingOrientationDeg: snapshot.buildingOrientationDeg,
+  });
+  rightPanel.updateSunEvents(events, {
+    useCivilTime: snapshot.useCivilTime,
+    timezoneOffsetHours: snapshot.timezoneOffsetHours,
+    longitudeDeg: snapshot.lonDeg,
+  });
+}
+
+applyState(store.getAll());
+store.subscribe((change, snapshot) => {
+  if (change?.key === "dayOfYear" || change?.key === "localTimeHours") {
+    if (animationMode !== "idle") {
+      // keep animation running but nothing special
+    }
+  }
+  applyState(snapshot);
+});

--- a/src/ui/leftPanel.js
+++ b/src/ui/leftPanel.js
@@ -1,0 +1,101 @@
+const PRESETS = [
+  { label: "Rome", lat: 41.9028, lon: 12.4964 },
+  { label: "Lyon", lat: 45.7640, lon: 4.8357 },
+  { label: "Amsterdam", lat: 52.3740, lon: 4.8952 },
+  { label: "Oslo", lat: 59.9133, lon: 10.7390 },
+];
+
+function formatDayOfYear(day) {
+  const base = new Date(Date.UTC(2024, 0, 1));
+  base.setUTCDate(day);
+  return base.toLocaleDateString("fr-FR", { day: "numeric", month: "short" });
+}
+
+function formatTime(hours) {
+  if (!Number.isFinite(hours)) return "--:--";
+  const h = Math.floor(hours);
+  const m = Math.round((hours - h) * 60);
+  return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
+}
+
+export function initLeftPanel({ mount, store, onManualChange }) {
+  const container = document.createElement("div");
+  container.className = "left-panel";
+  container.innerHTML = `
+    <section class="panel panel-compact">
+      <h3>Paramètres rapides</h3>
+      <div class="preset-buttons" data-role="presets"></div>
+    </section>
+    <section class="panel panel-compact">
+      <h3>Jour de l'année</h3>
+      <label class="slider-label-legend">Jour sélectionné : <span data-label="date">21 mar</span></label>
+      <input type="range" min="1" max="365" step="1" data-input="day" />
+      <div class="slider-label"><span>1 Jan</span><span>31 Déc</span></div>
+    </section>
+    <section class="panel panel-compact">
+      <h3>Heure solaire</h3>
+      <label class="slider-label-legend">Heure sélectionnée : <span data-label="time">12:00</span></label>
+      <input type="range" min="0" max="23.5" step="0.5" data-input="time" />
+      <div class="slider-label"><span>00:00</span><span>23:30</span></div>
+    </section>
+  `;
+  mount.appendChild(container);
+
+  const presetHost = container.querySelector('[data-role="presets"]');
+  PRESETS.forEach((preset) => {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "preset-btn";
+    btn.textContent = preset.label;
+    btn.addEventListener("click", () => {
+      store.set("latDeg", preset.lat);
+      store.set("lonDeg", preset.lon);
+      onManualChange?.("preset");
+    });
+    presetHost.appendChild(btn);
+  });
+
+  const daySlider = container.querySelector('[data-input="day"]');
+  const timeSlider = container.querySelector('[data-input="time"]');
+  const dateLabel = container.querySelector('[data-label="date"]');
+  const timeLabel = container.querySelector('[data-label="time"]');
+
+  function updateFromState(snapshot) {
+    if (snapshot.dayOfYear !== undefined) {
+      const dayValue = Number(snapshot.dayOfYear);
+      if (Number(daySlider.value) !== dayValue) {
+        daySlider.value = String(dayValue);
+      }
+      dateLabel.textContent = formatDayOfYear(dayValue);
+    }
+    if (snapshot.localTimeHours !== undefined) {
+      const timeValue = Number(snapshot.localTimeHours);
+      if (Number(timeSlider.value) !== timeValue) {
+        timeSlider.value = String(timeValue);
+      }
+      timeLabel.textContent = formatTime(timeValue);
+    }
+  }
+
+  daySlider.addEventListener("input", () => {
+    store.set("dayOfYear", Number(daySlider.value));
+    onManualChange?.("day");
+  });
+  timeSlider.addEventListener("input", () => {
+    store.set("localTimeHours", Number(timeSlider.value));
+    onManualChange?.("time");
+  });
+
+  const unsubscribe = store.subscribe((_, snapshot) => {
+    updateFromState(snapshot);
+  });
+
+  updateFromState(store.getAll());
+
+  return {
+    destroy() {
+      unsubscribe();
+      mount.removeChild(container);
+    },
+  };
+}

--- a/src/ui/results.js
+++ b/src/ui/results.js
@@ -1,0 +1,110 @@
+function formatDeg(value) {
+  return Number.isFinite(value) ? `${value.toFixed(1)}°` : "—";
+}
+
+function formatIrradiance(value) {
+  if (!Number.isFinite(value) || value <= 0) return "0 W/m²";
+  return `${Math.round(value)} W/m²`;
+}
+
+function toHM(hours) {
+  if (!Number.isFinite(hours)) return "—";
+  let h = Math.floor(hours);
+  let m = Math.round((hours - h) * 60);
+  if (m === 60) {
+    h += 1;
+    m = 0;
+  }
+  h = ((h % 24) + 24) % 24;
+  return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
+}
+
+export function createResultsView() {
+  const section = document.createElement("section");
+  section.className = "panel";
+  section.id = "results-panel";
+  section.innerHTML = `
+    <h3>Résultats</h3>
+    <div class="results-grid" aria-live="polite">
+      <div class="res-item"><div class="res-label">Altitude</div><div class="res-value" data-res="alt">—</div></div>
+      <div class="res-item"><div class="res-label">Azimut</div><div class="res-value" data-res="az">—</div></div>
+      <div class="res-item"><div class="res-label">Irradiance</div><div class="res-value" data-res="irr">—</div></div>
+      <div class="res-item"><div class="res-label">Incidence</div><div class="res-value" data-res="inc">—</div></div>
+    </div>
+  `;
+
+  const fields = {
+    alt: section.querySelector('[data-res="alt"]'),
+    az: section.querySelector('[data-res="az"]'),
+    irr: section.querySelector('[data-res="irr"]'),
+    inc: section.querySelector('[data-res="inc"]'),
+  };
+
+  function update(solarPosition) {
+    if (!solarPosition) {
+      fields.alt.textContent = "—";
+      fields.az.textContent = "—";
+      fields.irr.textContent = "0 W/m²";
+      fields.inc.textContent = "—";
+      return;
+    }
+    const altitude = solarPosition.altitudeDeg ?? solarPosition.elevation;
+    const azimuth = solarPosition.azimuthDeg ?? solarPosition.azimuth;
+    const irradiance = solarPosition.directIrradiance;
+    const incidence = solarPosition.incidenceAngleDeg ?? solarPosition.incidenceAngle;
+
+    fields.alt.textContent = formatDeg(altitude);
+    fields.az.textContent = formatDeg(azimuth);
+    fields.irr.textContent = formatIrradiance(irradiance);
+    fields.inc.textContent = formatDeg(incidence);
+  }
+
+  return { element: section, update };
+}
+
+export function createSunEventsView() {
+  const section = document.createElement("section");
+  section.className = "panel";
+  section.id = "sun-events-panel";
+  section.innerHTML = `
+    <h3>Moments clés du soleil</h3>
+    <div class="results-grid">
+      <div class="res-item"><div class="res-label">Lever</div><div class="res-value" data-event="sunrise">—</div></div>
+      <div class="res-item"><div class="res-label">Midi solaire</div><div class="res-value" data-event="solarnoon">—</div></div>
+      <div class="res-item"><div class="res-label">Coucher</div><div class="res-value" data-event="sunset">—</div></div>
+      <div class="res-item"><div class="res-label">Altitude max</div><div class="res-value" data-event="maxalt">—</div></div>
+    </div>
+  `;
+
+  const fields = {
+    sunrise: section.querySelector('[data-event="sunrise"]'),
+    solarnoon: section.querySelector('[data-event="solarnoon"]'),
+    sunset: section.querySelector('[data-event="sunset"]'),
+    maxalt: section.querySelector('[data-event="maxalt"]'),
+  };
+
+  function formatTime(value, { useCivilTime, timezoneOffsetHours, longitudeDeg }) {
+    if (!Number.isFinite(value)) return "—";
+    if (useCivilTime) {
+      const civil = value - timezoneOffsetHours + (longitudeDeg / 15);
+      return `${toHM(civil)} (civil≈)`;
+    }
+    return `${toHM(value)} (solaire)`;
+  }
+
+  function update(events, options) {
+    const opts = {
+      useCivilTime: false,
+      timezoneOffsetHours: 0,
+      longitudeDeg: 0,
+      ...(options || {}),
+    };
+    fields.sunrise.textContent = formatTime(events?.sunrise, opts);
+    fields.solarnoon.textContent = formatTime(events?.solarNoon, opts);
+    fields.sunset.textContent = formatTime(events?.sunset, opts);
+    const maxAlt = events?.maxAltitude;
+    fields.maxalt.textContent = Number.isFinite(maxAlt) ? `${maxAlt.toFixed(1)}°` : "—";
+  }
+
+  return { element: section, update };
+}

--- a/src/ui/rightPanel.js
+++ b/src/ui/rightPanel.js
@@ -1,0 +1,263 @@
+import { createResultsView, createSunEventsView } from "./results.js";
+
+function createInputsSection() {
+  const section = document.createElement("section");
+  section.className = "panel";
+  section.innerHTML = `
+    <h3>Entrées</h3>
+    <div class="form-field">
+      <label for="input-lat">Latitude (°)</label>
+      <input id="input-lat" type="number" min="-90" max="90" step="0.0001" />
+    </div>
+    <div class="form-field">
+      <label for="input-lon">Longitude (°)</label>
+      <input id="input-lon" type="number" min="-180" max="180" step="0.0001" />
+    </div>
+    <div class="form-field">
+      <label for="input-orientation">Azimut façade principale (°)</label>
+      <input id="input-orientation" type="number" min="0" max="360" step="1" />
+      <small>0°=Nord • 90°=Est • 180°=Sud • 270°=Ouest</small>
+    </div>
+    <div class="form-field-inline">
+      <label for="input-tz">Décalage fuseau (h)</label>
+      <input id="input-tz" type="number" step="0.25" min="-12" max="12" />
+    </div>
+    <div class="form-field-checkbox">
+      <input id="input-use-civil" type="checkbox" />
+      <label for="input-use-civil">Afficher les heures en temps civil approx.</label>
+    </div>
+  `;
+  return section;
+}
+
+function createInfoSection() {
+  const section = document.createElement("section");
+  section.className = "panel";
+  section.innerHTML = `
+    <h3>Contrôles 3D</h3>
+    <p><strong>Souris :</strong> rotation de la vue</p>
+    <p><strong>Molette :</strong> zoom avant/arrière</p>
+    <p><strong>Clic droit :</strong> panoramique</p>
+    <p><strong>Boutons :</strong> vues prédéfinies (dessus, profil, iso, libre)</p>
+  `;
+  return section;
+}
+
+export function initRightPanel({ mount, store, onOpenChange }) {
+  mount.setAttribute("role", "complementary");
+  mount.setAttribute("aria-label", "Panneau de données solaires");
+
+  const resultsView = createResultsView();
+  const eventsView = createSunEventsView();
+  const inputsSection = createInputsSection();
+  const infoSection = createInfoSection();
+
+  const container = document.createElement("div");
+  container.className = "right-panel";
+
+  const tabs = [
+    { id: "results", label: "Results", element: resultsView.element },
+    { id: "sun-events", label: "Sun events", element: eventsView.element },
+    { id: "inputs", label: "Inputs", element: inputsSection },
+    { id: "info", label: "Info", element: infoSection },
+  ];
+
+  const nav = document.createElement("div");
+  nav.className = "tabs-nav";
+  const contentHost = document.createElement("div");
+  contentHost.className = "tabs-content";
+
+  tabs.forEach((tab, index) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "tab-btn";
+    button.textContent = tab.label;
+    button.dataset.tab = tab.id;
+    if (index === 0) button.classList.add("active");
+    button.addEventListener("click", () => activate(tab.id));
+    nav.appendChild(button);
+
+    const wrapper = document.createElement("div");
+    wrapper.className = "tab-panel";
+    if (index === 0) wrapper.classList.add("active");
+    wrapper.dataset.tab = tab.id;
+    wrapper.appendChild(tab.element);
+    contentHost.appendChild(wrapper);
+  });
+
+  function activate(tabId) {
+    nav.querySelectorAll(".tab-btn").forEach((btn) => {
+      btn.classList.toggle("active", btn.dataset.tab === tabId);
+    });
+    contentHost.querySelectorAll(".tab-panel").forEach((panel) => {
+      panel.classList.toggle("active", panel.dataset.tab === tabId);
+    });
+  }
+
+  container.appendChild(nav);
+  container.appendChild(contentHost);
+  mount.appendChild(container);
+
+  const backdrop = document.createElement("div");
+  backdrop.className = "panel-right-backdrop";
+  document.body.appendChild(backdrop);
+
+  const drawerMedia = window.matchMedia?.("(max-width: 1200px)");
+  let drawerOpen = false;
+
+  function updateAria() {
+    mount.setAttribute("aria-expanded", drawerOpen ? "true" : "false");
+    if (drawerMedia?.matches) {
+      mount.setAttribute("aria-hidden", drawerOpen ? "false" : "true");
+    } else {
+      mount.removeAttribute("aria-hidden");
+    }
+  }
+
+  function notifyOpenChange(nextOpen) {
+    if (drawerOpen === nextOpen) {
+      updateAria();
+      return;
+    }
+    drawerOpen = nextOpen;
+    updateAria();
+    onOpenChange?.(drawerOpen);
+  }
+
+  function openDrawer({ focusFirst = false } = {}) {
+    if (!drawerMedia?.matches) return;
+    if (drawerOpen) return;
+    mount.classList.add("open");
+    backdrop.classList.add("active");
+    notifyOpenChange(true);
+    if (focusFirst) {
+      const firstTab = nav.querySelector(".tab-btn");
+      firstTab?.focus({ preventScroll: true });
+    }
+  }
+
+  function closeDrawer({ silent = false } = {}) {
+    mount.classList.remove("open");
+    backdrop.classList.remove("active");
+    if (!drawerOpen) {
+      updateAria();
+      return;
+    }
+    if (silent) {
+      drawerOpen = false;
+      updateAria();
+    } else {
+      notifyOpenChange(false);
+    }
+  }
+
+  function toggleDrawer() {
+    if (!drawerMedia?.matches) return;
+    if (drawerOpen) closeDrawer();
+    else openDrawer({ focusFirst: true });
+  }
+
+  function handleMediaChange(event) {
+    const matches = event?.matches ?? drawerMedia?.matches;
+    if (!matches) {
+      mount.classList.remove("open");
+      backdrop.classList.remove("active");
+      if (drawerOpen) {
+        notifyOpenChange(false);
+      } else {
+        updateAria();
+      }
+    } else {
+      updateAria();
+    }
+  }
+
+  handleMediaChange();
+  if (drawerMedia?.addEventListener) {
+    drawerMedia.addEventListener("change", handleMediaChange);
+  } else if (drawerMedia?.addListener) {
+    drawerMedia.addListener(handleMediaChange);
+  }
+
+  const onBackdropClick = () => closeDrawer();
+  backdrop.addEventListener("click", onBackdropClick);
+
+  function handleKeydown(event) {
+    if (event.key === "Escape" && drawerMedia?.matches && drawerOpen) {
+      event.preventDefault();
+      closeDrawer();
+    }
+  }
+
+  mount.addEventListener("keydown", handleKeydown);
+
+  const latInput = inputsSection.querySelector("#input-lat");
+  const lonInput = inputsSection.querySelector("#input-lon");
+  const orientationInput = inputsSection.querySelector("#input-orientation");
+  const tzInput = inputsSection.querySelector("#input-tz");
+  const civilCheckbox = inputsSection.querySelector("#input-use-civil");
+
+  latInput.addEventListener("change", () => {
+    const value = parseFloat(latInput.value);
+    if (!Number.isNaN(value)) store.set("latDeg", value);
+  });
+  lonInput.addEventListener("change", () => {
+    const value = parseFloat(lonInput.value);
+    if (!Number.isNaN(value)) store.set("lonDeg", value);
+  });
+  orientationInput.addEventListener("change", () => {
+    const value = parseFloat(orientationInput.value);
+    if (!Number.isNaN(value)) store.set("buildingOrientationDeg", value);
+  });
+  tzInput.addEventListener("change", () => {
+    const value = parseFloat(tzInput.value);
+    if (!Number.isNaN(value)) store.set("timezoneOffsetHours", value);
+  });
+  civilCheckbox.addEventListener("change", () => {
+    store.set("useCivilTime", civilCheckbox.checked);
+  });
+
+  function updateInputs(snapshot) {
+    if (snapshot.latDeg !== undefined && latInput.value !== String(snapshot.latDeg)) {
+      latInput.value = String(snapshot.latDeg);
+    }
+    if (snapshot.lonDeg !== undefined && lonInput.value !== String(snapshot.lonDeg)) {
+      lonInput.value = String(snapshot.lonDeg);
+    }
+    if (snapshot.buildingOrientationDeg !== undefined && orientationInput.value !== String(snapshot.buildingOrientationDeg)) {
+      orientationInput.value = String(snapshot.buildingOrientationDeg);
+    }
+    if (snapshot.timezoneOffsetHours !== undefined && tzInput.value !== String(snapshot.timezoneOffsetHours)) {
+      tzInput.value = String(snapshot.timezoneOffsetHours);
+    }
+    if (snapshot.useCivilTime !== undefined) {
+      civilCheckbox.checked = Boolean(snapshot.useCivilTime);
+    }
+  }
+
+  updateInputs(store.getAll());
+  const unsubscribe = store.subscribe((_, snapshot) => {
+    updateInputs(snapshot);
+  });
+
+  return {
+    updateResults: resultsView.update,
+    updateSunEvents: eventsView.update,
+    open: () => openDrawer({ focusFirst: true }),
+    close: () => closeDrawer(),
+    toggle: () => toggleDrawer(),
+    isOpen: () => drawerOpen,
+    destroy() {
+      unsubscribe();
+      backdrop.removeEventListener("click", onBackdropClick);
+      mount.removeEventListener("keydown", handleKeydown);
+      if (drawerMedia?.removeEventListener) {
+        drawerMedia.removeEventListener("change", handleMediaChange);
+      } else if (drawerMedia?.removeListener) {
+        drawerMedia.removeListener(handleMediaChange);
+      }
+      backdrop.remove();
+      mount.removeChild(container);
+    },
+  };
+}

--- a/src/ui/smoke.js
+++ b/src/ui/smoke.js
@@ -1,0 +1,34 @@
+export function initSmoke({ mount }) {
+  const indicator = document.createElement("div");
+  indicator.className = "smoke-test";
+  indicator.style.display = "none";
+  mount.appendChild(indicator);
+
+  function show(ok, message) {
+    indicator.textContent = message;
+    indicator.className = ok ? "smoke-test" : "smoke-test error";
+    indicator.style.display = "block";
+    setTimeout(() => {
+      indicator.style.display = "none";
+    }, 2000);
+  }
+
+  function run(name, fn) {
+    try {
+      const result = fn();
+      if (result) {
+        show(true, `✓ ${name}: OK`);
+        return true;
+      }
+      show(false, `✗ ${name}: ERREUR`);
+      console.error(`Smoke test ${name} failed`);
+      return false;
+    } catch (error) {
+      show(false, `✗ ${name}: ERREUR`);
+      console.error(`Smoke test ${name} failed`, error);
+      return false;
+    }
+  }
+
+  return { run, show };
+}

--- a/src/ui/toolbar.js
+++ b/src/ui/toolbar.js
@@ -1,0 +1,71 @@
+export function initToolbar({ mount, onPresetChange, onAnimationCommand, onToggleRightPanel }) {
+  const container = document.createElement("div");
+  container.className = "toolbar";
+  container.innerHTML = `
+    <div class="toolbar-group">
+      <span class="toolbar-title">Vues</span>
+      <button type="button" class="toolbar-btn" data-view="top">🔍 Dessus</button>
+      <button type="button" class="toolbar-btn" data-view="side">👁️ Profil</button>
+      <button type="button" class="toolbar-btn" data-view="iso">🔍 Iso</button>
+      <button type="button" class="toolbar-btn" data-view="free">🎮 Libre</button>
+    </div>
+    <div class="toolbar-group">
+      <span class="toolbar-title">Animations</span>
+      <button type="button" class="toolbar-btn" data-anim="day">▶️ Journée</button>
+      <button type="button" class="toolbar-btn" data-anim="year">🗓️ Année</button>
+      <button type="button" class="toolbar-btn" data-anim="stop">⏹️ Stop</button>
+    </div>
+    <div class="toolbar-group toolbar-mobile-only">
+      <button
+        type="button"
+        class="toolbar-btn"
+        data-role="toggle-right"
+        aria-expanded="false"
+        aria-label="Afficher les onglets de résultats"
+      >
+        📊 Onglets
+      </button>
+    </div>
+    <div class="toolbar-group toolbar-info">
+      <span class="toolbar-title">Caméra</span>
+      <span class="orbit-info" data-role="orbit-info">—</span>
+    </div>
+  `;
+  mount.appendChild(container);
+
+  container.querySelectorAll("[data-view]").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      onPresetChange?.(btn.dataset.view);
+    });
+  });
+
+  container.querySelectorAll("[data-anim]").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      onAnimationCommand?.(btn.dataset.anim);
+    });
+  });
+
+  const orbitInfoEl = container.querySelector('[data-role="orbit-info"]');
+  const toggleRightBtn = container.querySelector('[data-role="toggle-right"]');
+
+  if (toggleRightBtn) {
+    toggleRightBtn.addEventListener("click", () => {
+      onToggleRightPanel?.();
+    });
+  }
+
+  return {
+    setOrbitInfo(text) {
+      orbitInfoEl.textContent = text;
+    },
+    setRightPanelOpen(isOpen) {
+      if (!toggleRightBtn) return;
+      toggleRightBtn.classList.toggle("is-active", Boolean(isOpen));
+      toggleRightBtn.setAttribute("aria-expanded", String(Boolean(isOpen)));
+      toggleRightBtn.setAttribute(
+        "aria-label",
+        Boolean(isOpen) ? "Masquer les onglets de résultats" : "Afficher les onglets de résultats"
+      );
+    },
+  };
+}

--- a/src/view3d/controls3d.js
+++ b/src/view3d/controls3d.js
@@ -1,0 +1,127 @@
+import { RAD2DEG } from "../logic/sunMath.js";
+
+function getThree() {
+  const THREE = window.THREE;
+  if (!THREE) {
+    throw new Error("Three.js est requis pour les contrôles orbitaux");
+  }
+  return THREE;
+}
+
+export function attachOrbitControls({ camera, domElement, onChange }) {
+  const THREE = getThree();
+  const spherical = new THREE.Spherical();
+  spherical.setFromVector3(camera.position);
+
+  const state = {
+    dragging: false,
+    previous: { x: 0, y: 0 },
+  };
+
+  function syncCamera() {
+    camera.position.setFromSpherical(spherical);
+    camera.lookAt(0, 0, 0);
+    if (onChange) onChange();
+  }
+
+  function handlePointerDown(event) {
+    if (event.button !== 0 && event.button !== 2) return;
+    state.dragging = true;
+    state.previous.x = event.clientX;
+    state.previous.y = event.clientY;
+    event.preventDefault();
+  }
+
+  function handlePointerMove(event) {
+    if (!state.dragging) return;
+    const deltaX = event.clientX - state.previous.x;
+    const deltaY = event.clientY - state.previous.y;
+    state.previous.x = event.clientX;
+    state.previous.y = event.clientY;
+
+    spherical.theta -= deltaX * 0.01;
+    spherical.phi += deltaY * 0.01;
+    const epsilon = 0.1;
+    spherical.phi = Math.max(epsilon, Math.min(Math.PI - epsilon, spherical.phi));
+    syncCamera();
+  }
+
+  function handlePointerUp() {
+    state.dragging = false;
+  }
+
+  function handleWheel(event) {
+    event.preventDefault();
+    spherical.radius += event.deltaY * 0.01;
+    spherical.radius = Math.max(5, Math.min(50, spherical.radius));
+    syncCamera();
+  }
+
+  function preventContextMenu(event) {
+    event.preventDefault();
+  }
+
+  domElement.addEventListener("mousedown", handlePointerDown);
+  domElement.addEventListener("mousemove", handlePointerMove);
+  domElement.addEventListener("mouseup", handlePointerUp);
+  domElement.addEventListener("mouseleave", handlePointerUp);
+  domElement.addEventListener("wheel", handleWheel, { passive: false });
+  domElement.addEventListener("contextmenu", preventContextMenu);
+
+  return {
+    dispose() {
+      domElement.removeEventListener("mousedown", handlePointerDown);
+      domElement.removeEventListener("mousemove", handlePointerMove);
+      domElement.removeEventListener("mouseup", handlePointerUp);
+      domElement.removeEventListener("mouseleave", handlePointerUp);
+      domElement.removeEventListener("wheel", handleWheel);
+      domElement.removeEventListener("contextmenu", preventContextMenu);
+    },
+    sync() {
+      spherical.setFromVector3(camera.position);
+    },
+  };
+}
+
+export function setViewPreset({ camera, preset, onChange }) {
+  const distance = 25;
+  switch (preset) {
+    case "top":
+      camera.position.set(0, distance, 0);
+      break;
+    case "side":
+      camera.position.set(distance, 8, 0);
+      break;
+    case "iso":
+      camera.position.set(distance * 0.6, distance * 0.6, distance * 0.6);
+      break;
+    case "free":
+    default:
+      camera.position.set(18, 18, 18);
+      break;
+  }
+  camera.lookAt(0, 0, 0);
+  if (onChange) onChange();
+}
+
+export function updateOrbitInfo({ camera, element }) {
+  const position = camera.position;
+  const distance = position.length();
+  const azimuth = Math.atan2(position.x, position.z) * RAD2DEG;
+  const elevation = Math.asin(position.y / (distance || 1)) * RAD2DEG;
+
+  const normalizedAzimuth = Number.isFinite(azimuth) ? azimuth : 0;
+  const normalizedElevation = Number.isFinite(elevation) ? elevation : 0;
+  const normalizedDistance = Number.isFinite(distance) ? distance : 0;
+
+  const text = `Caméra - Azimut: ${normalizedAzimuth.toFixed(0)}° | Élévation: ${normalizedElevation.toFixed(0)}° | Distance: ${normalizedDistance.toFixed(1)}m`;
+  if (element) {
+    element.textContent = text;
+  }
+  return {
+    azimuth: normalizedAzimuth,
+    elevation: normalizedElevation,
+    distance: normalizedDistance,
+    text,
+  };
+}

--- a/src/view3d/viewer.js
+++ b/src/view3d/viewer.js
@@ -1,0 +1,422 @@
+import { calculateSolarPosition } from "../logic/rules.js";
+import { DEG2RAD } from "../logic/sunMath.js";
+
+const SCENE_SIZE = 20;
+const SUN_DISTANCE = 15;
+
+function getThree() {
+  const THREE = window.THREE;
+  if (!THREE) {
+    throw new Error("Three.js n'est pas chargé. Ajoutez <script src=...three.min.js></script> avant main.js");
+  }
+  return THREE;
+}
+
+function sphericalToCartesian(azimuthDeg, altitudeDeg, distance) {
+  const azimuthRad = (azimuthDeg - 90) * DEG2RAD;
+  const altitudeRad = altitudeDeg * DEG2RAD;
+  const x = distance * Math.cos(altitudeRad) * Math.cos(azimuthRad);
+  const z = distance * Math.cos(altitudeRad) * Math.sin(azimuthRad);
+  const y = distance * Math.sin(altitudeRad);
+  return { x, y, z };
+}
+
+function createGround(THREE) {
+  const geometry = new THREE.PlaneGeometry(SCENE_SIZE * 2, SCENE_SIZE * 2);
+  const material = new THREE.MeshLambertMaterial({ color: 0xF5DEB3 });
+  const ground = new THREE.Mesh(geometry, material);
+  ground.rotation.x = -Math.PI / 2;
+  ground.receiveShadow = true;
+  return ground;
+}
+
+function createBuilding(THREE) {
+  const group = new THREE.Group();
+
+  const bodyGeometry = new THREE.BoxGeometry(8, 6, 6);
+  const bodyMaterial = new THREE.MeshLambertMaterial({ color: 0x808080 });
+  const body = new THREE.Mesh(bodyGeometry, bodyMaterial);
+  body.position.y = 3;
+  body.castShadow = true;
+  body.receiveShadow = true;
+  group.add(body);
+
+  const roofGeometry = new THREE.ConeGeometry(5, 3, 4);
+  const roofMaterial = new THREE.MeshLambertMaterial({ color: 0xB22222 });
+  const roof = new THREE.Mesh(roofGeometry, roofMaterial);
+  roof.position.y = 7.5;
+  roof.rotation.y = Math.PI / 4;
+  roof.castShadow = true;
+  group.add(roof);
+
+  const windowGeometry = new THREE.PlaneGeometry(1.6, 2.4);
+  const windowMaterial = new THREE.MeshLambertMaterial({ color: 0x87CEEB });
+  for (let i = 0; i < 3; i += 1) {
+    const windowMesh = new THREE.Mesh(windowGeometry, windowMaterial);
+    windowMesh.position.set(-3 + i * 3, 3, 3.01);
+    group.add(windowMesh);
+  }
+
+  const doorGeometry = new THREE.PlaneGeometry(1.6, 4);
+  const doorMaterial = new THREE.MeshLambertMaterial({ color: 0x4B0082 });
+  const door = new THREE.Mesh(doorGeometry, doorMaterial);
+  door.position.set(0, 2, 3.01);
+  group.add(door);
+
+  return group;
+}
+
+function createSun(THREE) {
+  const sunGroup = new THREE.Group();
+
+  const sunGeometry = new THREE.SphereGeometry(0.5, 16, 16);
+  const sunMaterial = new THREE.MeshLambertMaterial({
+    color: 0xFDB813,
+    emissive: 0xFDB813,
+    emissiveIntensity: 0.3,
+  });
+  sunGroup.add(new THREE.Mesh(sunGeometry, sunMaterial));
+
+  const haloGeometry = new THREE.SphereGeometry(0.8, 16, 16);
+  const haloMaterial = new THREE.MeshBasicMaterial({
+    color: 0xFFD700,
+    transparent: true,
+    opacity: 0.2,
+  });
+  sunGroup.add(new THREE.Mesh(haloGeometry, haloMaterial));
+
+  for (let i = 0; i < 8; i += 1) {
+    const rayGeometry = new THREE.CylinderGeometry(0.02, 0.02, 2);
+    const rayMaterial = new THREE.MeshBasicMaterial({ color: 0xFFD700 });
+    const ray = new THREE.Mesh(rayGeometry, rayMaterial);
+    const angle = (i / 8) * Math.PI * 2;
+    ray.position.set(Math.cos(angle) * 1.2, 0, Math.sin(angle) * 1.2);
+    ray.rotation.z = angle;
+    sunGroup.add(ray);
+  }
+
+  return sunGroup;
+}
+
+function createCompassRose(THREE) {
+  const canvas = document.createElement("canvas");
+  const size = 512;
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) {
+    throw new Error("Canvas 2D context indisponible pour la rosace des vents");
+  }
+
+  ctx.clearRect(0, 0, size, size);
+  const center = size / 2;
+  const radius = size / 2 - 20;
+  ctx.lineWidth = 2;
+  ctx.strokeStyle = "#2F4F4F";
+  ctx.fillStyle = "#2F4F4F";
+
+  const directions = [
+    { label: "N", angle: 0 },
+    { label: "NNE", angle: 22.5 },
+    { label: "NE", angle: 45 },
+    { label: "ENE", angle: 67.5 },
+    { label: "E", angle: 90 },
+    { label: "ESE", angle: 112.5 },
+    { label: "SE", angle: 135 },
+    { label: "SSE", angle: 157.5 },
+    { label: "S", angle: 180 },
+    { label: "SSO", angle: 202.5 },
+    { label: "SO", angle: 225 },
+    { label: "OSO", angle: 247.5 },
+    { label: "O", angle: 270 },
+    { label: "ONO", angle: 292.5 },
+    { label: "NO", angle: 315 },
+    { label: "NNO", angle: 337.5 },
+  ];
+
+  directions.forEach((dir, index) => {
+    const angle = dir.angle * DEG2RAD;
+    const isMain = index % 4 === 0;
+    const isSecondary = index % 2 === 0;
+    const rayLength = isMain ? radius : isSecondary ? radius * 0.7 : radius * 0.5;
+    ctx.beginPath();
+    ctx.moveTo(center, center);
+    ctx.lineWidth = isMain ? 3 : isSecondary ? 2 : 1;
+    ctx.lineTo(center + Math.sin(angle) * rayLength, center - Math.cos(angle) * rayLength);
+    ctx.stroke();
+  });
+
+  ctx.font = "bold 32px Arial";
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  directions.forEach((dir) => {
+    const angle = dir.angle * DEG2RAD;
+    let labelDistance = radius + 35;
+    if (dir.label === "N") {
+      labelDistance = radius + 50;
+      ctx.font = "bold 40px Arial";
+      ctx.fillStyle = "#FF0000";
+    }
+    const x = center + Math.sin(angle) * labelDistance;
+    const y = center - Math.cos(angle) * labelDistance;
+    ctx.fillText(dir.label, x, y);
+    if (dir.label === "N") {
+      ctx.font = "bold 32px Arial";
+      ctx.fillStyle = "#2F4F4F";
+    }
+  });
+
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.needsUpdate = true;
+  const geometry = new THREE.PlaneGeometry(20, 20);
+  const material = new THREE.MeshBasicMaterial({
+    map: texture,
+    transparent: true,
+    side: THREE.DoubleSide,
+  });
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.rotation.x = -Math.PI / 2;
+  mesh.position.y = 0.01;
+  mesh.userData.isCompassRose = true;
+  return mesh;
+}
+
+function disposeObject(object) {
+  if (!object) return;
+  if (Array.isArray(object)) {
+    object.forEach(disposeObject);
+    return;
+  }
+  if (object.geometry) {
+    object.geometry.dispose();
+  }
+  if (object.material) {
+    if (Array.isArray(object.material)) {
+      object.material.forEach((mat) => mat.dispose && mat.dispose());
+    } else if (object.material.dispose) {
+      object.material.dispose();
+    }
+  }
+}
+
+function buildLegend(container) {
+  const legend = document.createElement("div");
+  legend.className = "seasonal-legend";
+  legend.innerHTML = `
+    <div class="legend-item"><div class="legend-color" style="background:#ff4444"></div><span>Solstice été (21 juin)</span></div>
+    <div class="legend-item"><div class="legend-color" style="background:#4444ff"></div><span>Solstice hiver (21 déc)</span></div>
+    <div class="legend-item"><div class="legend-color" style="background:#44ff44"></div><span>Équinoxes (21 mar/sep)</span></div>
+  `;
+  container.appendChild(legend);
+  return legend;
+}
+
+export function createViewer({ container, initialLatitude, initialOrientationDeg = 0 }) {
+  const THREE = getThree();
+  const scene = new THREE.Scene();
+  scene.background = new THREE.Color(0x87CEEB);
+
+  function clampSize(value) {
+    return Number.isFinite(value) && value > 0 ? value : 1;
+  }
+
+  const initialWidth = clampSize(container.clientWidth);
+  const initialHeight = clampSize(container.clientHeight);
+
+  const camera = new THREE.PerspectiveCamera(75, initialWidth / initialHeight, 0.1, 1000);
+  camera.position.set(15, 15, 15);
+  camera.lookAt(0, 0, 0);
+
+  const renderer = new THREE.WebGLRenderer({ antialias: true });
+  renderer.setPixelRatio(window.devicePixelRatio || 1);
+  renderer.setSize(initialWidth, initialHeight, false);
+  renderer.shadowMap.enabled = true;
+  renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+  container.appendChild(renderer.domElement);
+
+  const hintPan = document.createElement("div");
+  hintPan.className = "hint-pan";
+  hintPan.textContent = "🖱️ Clic gauche = orbite • Clic droit = pan";
+  container.appendChild(hintPan);
+
+  const legend = buildLegend(container);
+
+  const ambientLight = new THREE.AmbientLight(0x404040, 0.3);
+  scene.add(ambientLight);
+
+  const sunLight = new THREE.DirectionalLight(0xffffff, 1);
+  sunLight.castShadow = true;
+  sunLight.shadow.mapSize.width = 2048;
+  sunLight.shadow.mapSize.height = 2048;
+  sunLight.shadow.camera.near = 0.5;
+  sunLight.shadow.camera.far = 50;
+  sunLight.shadow.camera.left = -20;
+  sunLight.shadow.camera.right = 20;
+  sunLight.shadow.camera.top = 20;
+  sunLight.shadow.camera.bottom = -20;
+  scene.add(sunLight);
+  scene.add(sunLight.target);
+
+  const ground = createGround(THREE);
+  scene.add(ground);
+
+  const compassRose = createCompassRose(THREE);
+  scene.add(compassRose);
+
+  const building = createBuilding(THREE);
+  building.rotation.y = initialOrientationDeg * DEG2RAD;
+  scene.add(building);
+
+  const sun = createSun(THREE);
+  scene.add(sun);
+
+  let seasonalPaths = [];
+
+  function clearSeasonalPaths() {
+    seasonalPaths.forEach((path) => {
+      scene.remove(path);
+      disposeObject(path);
+    });
+    seasonalPaths = [];
+  }
+
+  function updateSeasonalPaths(latDeg) {
+    clearSeasonalPaths();
+    if (!Number.isFinite(latDeg)) return;
+
+    const seasons = [
+      { day: 172, color: 0xff4444 },
+      { day: 355, color: 0x4444ff },
+      { day: 80, color: 0x44ff44 },
+      { day: 266, color: 0x44ff44 },
+    ];
+
+    seasons.forEach((season) => {
+      const points = [];
+      for (let hour = 6; hour <= 18; hour += 0.5) {
+        const pos = calculateSolarPosition({
+          dayOfYear: season.day,
+          localTimeHours: hour,
+          latDeg,
+          lonDeg: 0,
+          buildingOrientationDeg: 0,
+        });
+        const altitude = pos.altitudeDeg ?? pos.elevation ?? 0;
+        if (altitude > 0) {
+          const azimuth = pos.azimuthDeg ?? pos.azimuth ?? 0;
+          const coords = sphericalToCartesian(azimuth, altitude, SUN_DISTANCE);
+          points.push(new THREE.Vector3(coords.x, coords.y, coords.z));
+        }
+      }
+      if (points.length > 1) {
+        const curve = new THREE.CatmullRomCurve3(points);
+        const geometry = new THREE.TubeGeometry(curve, 100, 0.05, 8, false);
+        const material = new THREE.MeshBasicMaterial({ color: season.color });
+        const mesh = new THREE.Mesh(geometry, material);
+        scene.add(mesh);
+        seasonalPaths.push(mesh);
+      }
+    });
+  }
+
+  function updateSunPosition(solarPosition) {
+    if (!solarPosition) return;
+    const altitude = solarPosition.altitudeDeg ?? solarPosition.elevation ?? 0;
+    const azimuth = solarPosition.azimuthDeg ?? solarPosition.azimuth ?? 0;
+
+    if (altitude > 0) {
+      const coords = sphericalToCartesian(azimuth, altitude, SUN_DISTANCE);
+      sun.visible = true;
+      sun.position.set(coords.x, coords.y, coords.z);
+      sunLight.position.copy(sun.position);
+      sunLight.target.position.set(0, 0, 0);
+      sunLight.intensity = Math.max(0.3, altitude / 90);
+    } else {
+      sun.visible = false;
+      sunLight.intensity = 0;
+    }
+  }
+
+  function updateBuildingOrientation(deg) {
+    if (!Number.isFinite(deg)) return;
+    building.rotation.y = deg * DEG2RAD;
+  }
+
+  function resize(explicitWidth, explicitHeight) {
+    const w = clampSize(explicitWidth ?? container.clientWidth);
+    const h = clampSize(explicitHeight ?? container.clientHeight);
+    renderer.setSize(w, h, false);
+    camera.aspect = w / h;
+    camera.updateProjectionMatrix();
+    hasResolvedInitialSize = true;
+  }
+
+  let resizeObserver = null;
+  let hasResolvedInitialSize = initialWidth > 1 || initialHeight > 1;
+
+  function ensureInitialSize() {
+    if (hasResolvedInitialSize) return;
+    const { clientWidth, clientHeight } = container;
+    if (clientWidth > 0 && clientHeight > 0) {
+      hasResolvedInitialSize = true;
+      resize(clientWidth, clientHeight);
+    } else {
+      requestAnimationFrame(ensureInitialSize);
+    }
+  }
+
+  ensureInitialSize();
+
+  if (typeof ResizeObserver === "function") {
+    resizeObserver = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        if (entry.target === container) {
+          const { width, height } = entry.contentRect;
+          if (width > 0 && height > 0) {
+            hasResolvedInitialSize = true;
+            resize(width, height);
+            return;
+          }
+        }
+      }
+      resize();
+    });
+    resizeObserver.observe(container);
+  }
+
+  let rafId = 0;
+  function renderLoop() {
+    rafId = requestAnimationFrame(renderLoop);
+    renderer.render(scene, camera);
+  }
+  renderLoop();
+
+  function dispose() {
+    cancelAnimationFrame(rafId);
+    clearSeasonalPaths();
+    disposeObject(ground);
+    disposeObject(compassRose);
+    disposeObject(building);
+    disposeObject(sun);
+    renderer.dispose();
+    legend.remove();
+    hintPan.remove();
+    if (resizeObserver) {
+      resizeObserver.disconnect();
+      resizeObserver = null;
+    }
+  }
+
+  updateSeasonalPaths(initialLatitude);
+
+  return {
+    scene,
+    camera,
+    renderer,
+    updateSunPosition,
+    updateBuildingOrientation,
+    updateSeasonalPaths,
+    resize,
+    dispose,
+  };
+}

--- a/tests/solarEngine.snapshots.mjs
+++ b/tests/solarEngine.snapshots.mjs
@@ -1,0 +1,228 @@
+import assert from "node:assert/strict";
+import { calculateSolarPosition, computeSunEvents } from "../src/logic/rules.js";
+
+const DEG2RAD = Math.PI / 180;
+const RAD2DEG = 180 / Math.PI;
+const SOLAR_CONSTANT = 1361;
+
+function normalizeAngle(angle) {
+  const normalized = angle % 360;
+  return normalized < 0 ? normalized + 360 : normalized;
+}
+
+function legacySolarDeclination(dayOfYear) {
+  return 23.45 * Math.sin(DEG2RAD * (360 * (284 + dayOfYear) / 365));
+}
+
+function legacyEquationOfTime(dayOfYear) {
+  const B = DEG2RAD * (360 * (dayOfYear - 1) / 365);
+  return 4 * (
+    0.000075 +
+    0.001868 * Math.cos(B) -
+    0.032077 * Math.sin(B) -
+    0.014615 * Math.cos(2 * B) -
+    0.04089  * Math.sin(2 * B)
+  );
+}
+
+function legacyAirMassKY(elevationDeg) {
+  if (elevationDeg <= 0) return Infinity;
+  const h = elevationDeg;
+  return 1 / (
+    Math.sin(h * DEG2RAD) +
+    0.50572 * Math.pow(h + 6.07995, -1.6364)
+  );
+}
+
+function legacyEarthSunDistance(dayOfYear) {
+  return 1 - 0.0167 * Math.cos(DEG2RAD * (360 * (dayOfYear - 4) / 365));
+}
+
+function legacyCalculateSolarPosition({ dayOfYear, hour, latitude, longitude, buildingOrientationDeg = 0 }) {
+  const declination = legacySolarDeclination(dayOfYear);
+  const equationOfTime = legacyEquationOfTime(dayOfYear);
+  const solarTime = hour + longitude / 15 + equationOfTime / 60;
+  const hourAngle = 15 * (solarTime - 12);
+
+  const latRad = latitude * DEG2RAD;
+  const decRad = declination * DEG2RAD;
+  const hourAngleRad = hourAngle * DEG2RAD;
+
+  const elevationRad = Math.asin(
+    Math.sin(latRad) * Math.sin(decRad) +
+    Math.cos(latRad) * Math.cos(decRad) * Math.cos(hourAngleRad)
+  );
+  const elevation = elevationRad * RAD2DEG;
+
+  const azimuthRad = Math.atan2(
+    Math.sin(hourAngleRad),
+    Math.cos(hourAngleRad) * Math.sin(latRad) - Math.tan(decRad) * Math.cos(latRad)
+  );
+  let azimuth = azimuthRad * RAD2DEG + 180;
+  azimuth = normalizeAngle(azimuth);
+
+  const earthSunDistance = legacyEarthSunDistance(dayOfYear);
+  const azimuthRelative = normalizeAngle(azimuth - buildingOrientationDeg);
+  const incidenceAngle = azimuthRelative > 180 ? 360 - azimuthRelative : azimuthRelative;
+
+  const airMass = legacyAirMassKY(elevation);
+
+  let directIrradiance = 0;
+  if (elevation > 0 && incidenceAngle < 90) {
+    const effectiveAirMass = Math.min(airMass, 38);
+    const atmosphericAttenuation = Math.pow(0.7, Math.pow(effectiveAirMass, 0.678));
+    const cosIncidence = Math.cos(incidenceAngle * DEG2RAD);
+    directIrradiance = (SOLAR_CONSTANT * atmosphericAttenuation * cosIncidence) /
+      (earthSunDistance * earthSunDistance);
+  }
+
+  return {
+    azimuth,
+    elevation,
+    declination,
+    hourAngle,
+    equationOfTimeMinutes: equationOfTime,
+    localSolarTimeHours: solarTime,
+    earthSunDistance,
+    directIrradiance,
+    incidenceAngle,
+    azimuthFromOrientationDeg: azimuthRelative,
+    airMass
+  };
+}
+
+function legacyComputeSunEvents({ dayOfYear, latitude, longitude, stepHours = 0.25 }) {
+  let prevElev = null;
+  let prevT = null;
+  let sunrise = NaN;
+  let sunset = NaN;
+  let maxAlt = -Infinity;
+  let tMax = NaN;
+
+  for (let t = 0; t <= 24 + 1e-9; t += stepHours) {
+    const pos = legacyCalculateSolarPosition({ dayOfYear, hour: t, latitude, longitude });
+    const elev = pos.elevation;
+
+    if (elev > maxAlt) {
+      maxAlt = elev;
+      tMax = t;
+    }
+
+    if (prevElev !== null) {
+      const crossed = (prevElev <= 0 && elev > 0) || (prevElev >= 0 && elev < 0);
+      if (crossed) {
+        const frac = prevElev === elev ? 0 : (0 - prevElev) / (elev - prevElev);
+        const tcross = prevT + frac * (t - prevT);
+        if (elev > prevElev && Number.isNaN(sunrise)) sunrise = tcross;
+        else if (elev < prevElev) sunset = tcross;
+      }
+    }
+
+    prevElev = elev;
+    prevT = t;
+  }
+
+  return { sunrise, sunset, solarNoon: tMax, maxAltitude: maxAlt };
+}
+
+function assertAlmostEqual(actual, expected, tolerance, message) {
+  if (Number.isNaN(expected) && Number.isNaN(actual)) return;
+  if (!Number.isFinite(expected) && !Number.isFinite(actual)) return;
+  assert.ok(Math.abs(actual - expected) <= tolerance,
+    `${message} (expected ${expected}, got ${actual})`);
+}
+
+const daySamples = [20, 172, 355];
+const hourSamples = [6, 12, 18];
+const latLonSamples = [
+  { label: "Paris", latDeg: 48.8566, lonDeg: 2.3522 },
+  { label: "Sydney", latDeg: -33.8688, lonDeg: 151.2093 }
+];
+const orientations = [0, 45];
+
+const snapshotTable = [];
+
+for (const location of latLonSamples) {
+  for (const dayOfYear of daySamples) {
+    for (const localTimeHours of hourSamples) {
+      for (const orientation of orientations) {
+        const modern = calculateSolarPosition({
+          dayOfYear,
+          localTimeHours,
+          latDeg: location.latDeg,
+          lonDeg: location.lonDeg,
+          buildingOrientationDeg: orientation,
+          radius: 10
+        });
+
+        const legacy = legacyCalculateSolarPosition({
+          dayOfYear,
+          hour: localTimeHours,
+          latitude: location.latDeg,
+          longitude: location.lonDeg,
+          buildingOrientationDeg: orientation
+        });
+
+        const context = `${location.label} D${dayOfYear} T${localTimeHours}h Ori${orientation}`;
+
+        assertAlmostEqual(modern.altitudeDeg, legacy.elevation, 1e-6, `${context} altitude`);
+        assertAlmostEqual(modern.azimuthDeg, legacy.azimuth, 1e-6, `${context} azimuth`);
+        assertAlmostEqual(modern.declinationDeg, legacy.declination, 1e-6, `${context} declination`);
+        assertAlmostEqual(modern.hourAngleDeg, legacy.hourAngle, 1e-6, `${context} hourAngle`);
+        assertAlmostEqual(modern.equationOfTimeMinutes, legacy.equationOfTimeMinutes, 1e-6, `${context} equationOfTime`);
+        assertAlmostEqual(modern.localSolarTimeHours, legacy.localSolarTimeHours, 1e-6, `${context} localSolarTime`);
+        assertAlmostEqual(modern.earthSunDistance, legacy.earthSunDistance, 1e-8, `${context} earthSunDistance`);
+        assertAlmostEqual(modern.airMass, legacy.airMass, 1e-6, `${context} airMass`);
+        assertAlmostEqual(modern.azimuthFromOrientationDeg, legacy.azimuthFromOrientationDeg, 1e-6, `${context} relativeAz`);
+        assertAlmostEqual(modern.incidenceAngleDeg, legacy.incidenceAngle, 1e-6, `${context} incidenceAngle`);
+        assertAlmostEqual(modern.directIrradiance, legacy.directIrradiance, 1e-3, `${context} directIrradiance`);
+
+        snapshotTable.push({
+          location: location.label,
+          day: dayOfYear,
+          time: localTimeHours,
+          orientation,
+          altitude: Number(modern.altitudeDeg.toFixed(2)),
+          azimuth: Number(modern.azimuthDeg.toFixed(2)),
+          irradiance: Number(modern.directIrradiance.toFixed(1))
+        });
+      }
+    }
+  }
+}
+
+const eventsTable = [];
+for (const location of latLonSamples) {
+  for (const dayOfYear of daySamples) {
+    const modern = computeSunEvents({
+      dayOfYear,
+      latDeg: location.latDeg,
+      lonDeg: location.lonDeg
+    });
+    const legacy = legacyComputeSunEvents({
+      dayOfYear,
+      latitude: location.latDeg,
+      longitude: location.lonDeg
+    });
+
+    const context = `${location.label} D${dayOfYear}`;
+    assertAlmostEqual(modern.sunrise, legacy.sunrise, 1e-4, `${context} sunrise`);
+    assertAlmostEqual(modern.sunset, legacy.sunset, 1e-4, `${context} sunset`);
+    assertAlmostEqual(modern.solarNoon, legacy.solarNoon, 1e-4, `${context} solarNoon`);
+    assertAlmostEqual(modern.maxAltitude, legacy.maxAltitude, 1e-4, `${context} maxAltitude`);
+
+    eventsTable.push({
+      location: location.label,
+      day: dayOfYear,
+      sunrise: Number.isFinite(modern.sunrise) ? modern.sunrise.toFixed(2) : "—",
+      solarNoon: Number.isFinite(modern.solarNoon) ? modern.solarNoon.toFixed(2) : "—",
+      sunset: Number.isFinite(modern.sunset) ? modern.sunset.toFixed(2) : "—",
+      maxAltitude: Number.isFinite(modern.maxAltitude) ? modern.maxAltitude.toFixed(1) : "—"
+    });
+  }
+}
+
+console.log(`Validated ${snapshotTable.length} solar position snapshots.`);
+console.table(snapshotTable);
+console.log("\nValidated sun event computations:");
+console.table(eventsTable);


### PR DESCRIPTION
## Summary
- make the three-column layout fluid with clamp/minmax widths, min-width fixes, and a drawer/backdrop version of the right panel for narrow screens
- add a mobile toggle in the toolbar, wire it to the right panel state via the store, and document the new responsive behaviour in the README
- safeguard the Three.js viewer with a ResizeObserver-driven resize routine so the canvas initializes at the correct size

## Testing
- node tests/solarEngine.snapshots.mjs

------
https://chatgpt.com/codex/tasks/task_e_68c9a60b92d883228e5afe0f65d3a1ca