### PR TITLE
Remove camera orbit info from toolbar

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -124,7 +124,6 @@ input[type="range"]::-moz-range-thumb {
   transition: background 0.2s, transform 0.2s;
 }
 .toolbar-btn:hover { background: #e5f0ff; transform: translateY(-1px); }
-.toolbar-info { margin-left: auto; }
 
 .viewer-host {
   position: relative;

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,7 @@
 import { store } from "./state/store.js";
 import { calculateSolarPosition, computeSunEvents } from "./logic/rules.js";
 import { createViewer } from "./view3d/viewer.js";
-import { attachOrbitControls, setViewPreset, updateOrbitInfo } from "./view3d/controls3d.js";
+import { attachOrbitControls, setViewPreset } from "./view3d/controls3d.js";
 import { initLeftPanel } from "./ui/leftPanel.js";
 import { initRightPanel } from "./ui/rightPanel.js";
 import { initToolbar } from "./ui/toolbar.js";
@@ -38,23 +38,13 @@ const viewer = createViewer({
 smoke.run("Initialisation conteneur", () => !!viewerHost);
 smoke.run("Three.js prêt", () => !!viewer?.renderer?.domElement);
 
-let toolbarApi = null;
 const controls = attachOrbitControls({
   camera: viewer.camera,
   domElement: viewer.renderer.domElement,
-  onChange: () => {
-    const info = updateOrbitInfo({ camera: viewer.camera });
-    toolbarApi?.setOrbitInfo(info.text);
-  },
 });
 
-function refreshOrbitInfo() {
-  const info = updateOrbitInfo({ camera: viewer.camera });
-  toolbarApi?.setOrbitInfo(info.text);
-}
-
 function handlePresetChange(preset) {
-  setViewPreset({ camera: viewer.camera, preset, onChange: refreshOrbitInfo });
+  setViewPreset({ camera: viewer.camera, preset });
   controls.sync();
 }
 
@@ -113,12 +103,11 @@ function handleAnimationCommand(command) {
   else stopAnimation();
 }
 
-toolbarApi = initToolbar({
+initToolbar({
   mount: toolbarMount,
   onPresetChange: handlePresetChange,
   onAnimationCommand: handleAnimationCommand,
 });
-refreshOrbitInfo();
 
 initLeftPanel({
   mount: leftMount,

--- a/src/ui/toolbar.js
+++ b/src/ui/toolbar.js
@@ -15,10 +15,6 @@ export function initToolbar({ mount, onPresetChange, onAnimationCommand }) {
       <button type="button" class="toolbar-btn" data-anim="year">🗓️ Année</button>
       <button type="button" class="toolbar-btn" data-anim="stop">⏹️ Stop</button>
     </div>
-    <div class="toolbar-group toolbar-info">
-      <span class="toolbar-title">Caméra</span>
-      <span class="orbit-info" data-role="orbit-info">—</span>
-    </div>
   `;
   mount.appendChild(container);
 
@@ -34,11 +30,4 @@ export function initToolbar({ mount, onPresetChange, onAnimationCommand }) {
     });
   });
 
-  const orbitInfoEl = container.querySelector('[data-role="orbit-info"]');
-
-  return {
-    setOrbitInfo(text) {
-      orbitInfoEl.textContent = text;
-    },
-  };
 }

--- a/src/view3d/controls3d.js
+++ b/src/view3d/controls3d.js
@@ -1,5 +1,3 @@
-import { RAD2DEG } from "../logic/sunMath.js";
-
 function getThree() {
   const THREE = window.THREE;
   if (!THREE) {
@@ -83,7 +81,7 @@ export function attachOrbitControls({ camera, domElement, onChange }) {
   };
 }
 
-export function setViewPreset({ camera, preset, onChange }) {
+export function setViewPreset({ camera, preset }) {
   const distance = 25;
   switch (preset) {
     case "top":
@@ -101,27 +99,5 @@ export function setViewPreset({ camera, preset, onChange }) {
       break;
   }
   camera.lookAt(0, 0, 0);
-  if (onChange) onChange();
 }
 
-export function updateOrbitInfo({ camera, element }) {
-  const position = camera.position;
-  const distance = position.length();
-  const azimuth = Math.atan2(position.x, position.z) * RAD2DEG;
-  const elevation = Math.asin(position.y / (distance || 1)) * RAD2DEG;
-
-  const normalizedAzimuth = Number.isFinite(azimuth) ? azimuth : 0;
-  const normalizedElevation = Number.isFinite(elevation) ? elevation : 0;
-  const normalizedDistance = Number.isFinite(distance) ? distance : 0;
-
-  const text = `Caméra - Azimut: ${normalizedAzimuth.toFixed(0)}° | Élévation: ${normalizedElevation.toFixed(0)}° | Distance: ${normalizedDistance.toFixed(1)}m`;
-  if (element) {
-    element.textContent = text;
-  }
-  return {
-    azimuth: normalizedAzimuth,
-    elevation: normalizedElevation,
-    distance: normalizedDistance,
-    text,
-  };
-}


### PR DESCRIPTION
## Summary
- remove the camera information block from the toolbar layout and related styles
- simplify main viewer setup now that orbit info updates are no longer needed
- clean up 3D controls by removing the unused camera info helper

## Testing
- npm run test:snapshots

------
https://chatgpt.com/codex/tasks/task_e_68cb0f2c7794832280e2cde7e642fd26