### PR TITLE
Implement wave 1 fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,12 @@
 
     <div id="right-panel-backdrop" class="panel-right-backdrop" aria-hidden="true"></div>
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"
+      integrity="sha512-f2x8pFazc2DSES0finBmMOPqlmkavRKu0kUQeFk/gQq/i323iDL49myIIZeF1P0uohsEiL/KZ8nfdXbra+6xMw=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    ></script>
     <script type="module" src="./src/main.js"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "test:snapshots": "node tests/solarEngine.snapshots.mjs"
+    "test:unit": "node tests/unit.mjs",
+    "test:snapshots": "node tests/solarEngine.snapshots.mjs",
+    "test": "npm run test:unit && npm run test:snapshots"
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -120,6 +120,17 @@ const rightPanel = initRightPanel({ mount: rightMount, store });
 window.addEventListener("resize", () => viewer.resize());
 
 let lastLatitude = store.get("latDeg");
+let lastSunEventsInput = null;
+let lastSunEventsResult = null;
+
+function hasSameEventInputs(a, b) {
+  return (
+    a?.dayOfYear === b?.dayOfYear &&
+    a?.latDeg === b?.latDeg &&
+    a?.lonDeg === b?.lonDeg &&
+    a?.buildingOrientationDeg === b?.buildingOrientationDeg
+  );
+}
 
 function applyState(snapshot) {
   const requiredKeys = ["dayOfYear", "localTimeHours", "latDeg", "lonDeg", "buildingOrientationDeg"];
@@ -143,12 +154,19 @@ function applyState(snapshot) {
     lastLatitude = snapshot.latDeg;
   }
 
-  const events = computeSunEvents({
+  const eventsInput = {
     dayOfYear: snapshot.dayOfYear,
     latDeg: snapshot.latDeg,
     lonDeg: snapshot.lonDeg,
     buildingOrientationDeg: snapshot.buildingOrientationDeg,
-  });
+  };
+
+  if (!hasSameEventInputs(eventsInput, lastSunEventsInput)) {
+    lastSunEventsResult = computeSunEvents(eventsInput);
+    lastSunEventsInput = { ...eventsInput };
+  }
+
+  const events = lastSunEventsResult;
   rightPanel.updateSunEvents(events, {
     useCivilTime: snapshot.useCivilTime,
     timezoneOffsetHours: snapshot.timezoneOffsetHours,

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -1,10 +1,44 @@
 // Minimal global store (pub/sub) — prêt pour PR2+
-const state = {};
-const listeners = new Set();
+export function createStore(initial = {}) {
+  const state = { ...initial };
+  const listeners = new Set();
 
-export const store = {
-  get: (k) => state[k],
-  getAll: () => ({ ...state }),
-  set: (k, v) => { state[k] = v; listeners.forEach(fn => fn({ key: k, value: v }, { ...state })); },
-  subscribe: (fn) => (listeners.add(fn), () => listeners.delete(fn)),
-};
+  function notify(change) {
+    const snapshot = { ...state };
+    listeners.forEach((fn) => fn(change, snapshot));
+  }
+
+  return {
+    get: (k) => state[k],
+    getAll: () => ({ ...state }),
+    set: (k, v) => {
+      if (Object.is(state[k], v)) return;
+      state[k] = v;
+      notify({ key: k, value: v });
+    },
+    setMany: (patch) => {
+      const entries = Object.entries(patch || {});
+      if (!entries.length) return;
+
+      const changed = [];
+      for (const [key, value] of entries) {
+        if (Object.is(state[key], value)) continue;
+        state[key] = value;
+        changed.push([key, value]);
+      }
+
+      if (!changed.length) return;
+
+      const [lastKey, lastValue] = changed[changed.length - 1];
+      notify({
+        key: lastKey,
+        value: lastValue,
+        keys: changed.map(([key]) => key),
+        values: Object.fromEntries(changed),
+      });
+    },
+    subscribe: (fn) => (listeners.add(fn), () => listeners.delete(fn)),
+  };
+}
+
+export const store = createStore();

--- a/src/ui/leftPanel.js
+++ b/src/ui/leftPanel.js
@@ -5,9 +5,10 @@ const PRESETS = [
   { label: "Oslo", lat: 59.9133, lon: 10.7390 },
 ];
 
-function formatDayOfYear(day) {
-  const base = new Date(Date.UTC(2024, 0, 1));
-  base.setUTCDate(day);
+export function formatDayOfYear(day) {
+  const value = Number.isFinite(day) ? Math.min(Math.max(1, Math.round(day)), 365) : 1;
+  const base = new Date(Date.UTC(2021, 0, 1));
+  base.setUTCDate(value);
   return base.toLocaleDateString("fr-FR", { day: "numeric", month: "short" });
 }
 
@@ -48,8 +49,7 @@ export function initLeftPanel({ mount, store, onManualChange }) {
     btn.className = "preset-btn";
     btn.textContent = preset.label;
     btn.addEventListener("click", () => {
-      store.set("latDeg", preset.lat);
-      store.set("lonDeg", preset.lon);
+      store.setMany({ latDeg: preset.lat, lonDeg: preset.lon });
       onManualChange?.("preset");
     });
     presetHost.appendChild(btn);

--- a/tests/unit.mjs
+++ b/tests/unit.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+
+const { formatDayOfYear } = await import("../src/ui/leftPanel.js");
+
+assert.equal(formatDayOfYear(1), "1 janv.");
+assert.equal(formatDayOfYear(60), "1 mars");
+assert.equal(formatDayOfYear(172), "21 juin");
+assert.equal(formatDayOfYear(0), "1 janv.");
+
+const { createStore } = await import("../src/state/store.js");
+
+const store = createStore();
+let notifications = 0;
+store.subscribe(() => {
+  notifications += 1;
+});
+
+store.set("foo", 42);
+store.set("foo", 42);
+store.set("foo", 43);
+
+assert.equal(notifications, 2, "store.set should ignore unchanged values");
+
+const batchedStore = createStore();
+const received = [];
+batchedStore.subscribe((change) => {
+  received.push(change);
+});
+
+batchedStore.setMany({ latDeg: 10, lonDeg: 20 });
+batchedStore.setMany({ latDeg: 10 });
+
+assert.equal(received.length, 1, "setMany should notify once for changes");
+assert.deepEqual(received[0].keys, ["latDeg", "lonDeg"]);
+assert.equal(batchedStore.get("latDeg"), 10);
+assert.equal(batchedStore.get("lonDeg"), 20);
+
+console.log("All unit checks passed");


### PR DESCRIPTION
## Summary
- correct day-of-year formatting to avoid leap-year drift and expose helper for testing
- add guard rails and batching support to the store to reduce redundant recomputation
- cache sun event computations, secure three.js loading with SRI, and add unit tests plus npm scripts

## Testing
- npm run test:unit
- npm run test:snapshots

------
https://chatgpt.com/codex/tasks/task_e_68cb134e725c83228d12ca3876f3132f