### PR TITLE
Refine left panel with card-based quick controls

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -182,6 +182,160 @@ p {
   box-shadow: var(--shadow-panel-subtle);
   min-width: 0;
 }
+#app .quick-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  padding: var(--space-5);
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.88), rgba(236, 243, 255, 0.55));
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
+  backdrop-filter: blur(18px);
+}
+
+.quick-card-header {
+  display: flex;
+  gap: var(--space-4);
+  align-items: flex-start;
+}
+
+.quick-card-icon {
+  width: 42px;
+  height: 42px;
+  border-radius: 14px;
+  display: grid;
+  place-items: center;
+  font-size: 1.25rem;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.2), rgba(14, 165, 233, 0.25));
+  color: var(--color-accent);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.quick-card-copy {
+  margin-top: 4px;
+  font-size: 0.95rem;
+  color: var(--color-text-secondary);
+}
+
+.preset-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-3);
+}
+
+.preset-chip {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.55rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(99, 102, 241, 0.25);
+  background: linear-gradient(135deg, rgba(191, 219, 254, 0.28), rgba(219, 234, 254, 0.18));
+  color: var(--color-text-primary);
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.preset-chip:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.15);
+}
+
+.preset-chip.is-active {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.95), rgba(14, 165, 233, 0.9));
+  color: #f8fafc;
+  box-shadow: 0 16px 28px rgba(37, 99, 235, 0.3);
+  border-color: transparent;
+}
+
+.slider-track {
+  position: relative;
+  padding: var(--space-3) var(--space-2) calc(var(--space-2) * 0.5);
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.45), rgba(226, 232, 240, 0.35));
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: inset 0 1px 1px rgba(255, 255, 255, 0.6), 0 12px 24px rgba(15, 23, 42, 0.15);
+  backdrop-filter: blur(16px);
+  --value-progress: 50%;
+}
+
+.slider-track input[type="range"] {
+  width: 100%;
+  -webkit-appearance: none;
+  appearance: none;
+  height: 10px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(37, 99, 235, 0.85) var(--value-progress), rgba(226, 232, 240, 0.65) var(--value-progress));
+  outline: none;
+  transition: background 0.2s ease;
+}
+
+.slider-track input[type="range"]:focus-visible {
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.3);
+}
+
+.slider-track input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #2563eb, #3b82f6);
+  border: 2px solid #eef2ff;
+  box-shadow: 0 4px 10px rgba(37, 99, 235, 0.45);
+  cursor: pointer;
+  position: relative;
+}
+
+.slider-track input[type="range"]::-moz-range-thumb {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #2563eb, #3b82f6);
+  border: 2px solid #eef2ff;
+  box-shadow: 0 4px 10px rgba(37, 99, 235, 0.45);
+  cursor: pointer;
+}
+
+.slider-track input[type="range"]::-moz-range-progress {
+  background: rgba(37, 99, 235, 0.85);
+  height: 10px;
+  border-radius: 999px;
+}
+
+.slider-track input[type="range"]::-moz-range-track {
+  background: rgba(226, 232, 240, 0.65);
+  height: 10px;
+  border-radius: 999px;
+}
+
+.value-pill {
+  position: absolute;
+  top: 0;
+  left: var(--value-progress);
+  transform: translate(-50%, -70%);
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.95), rgba(56, 189, 248, 0.9));
+  color: #f8fafc;
+  font-weight: 600;
+  font-size: 0.75rem;
+  letter-spacing: 0.02em;
+  box-shadow: 0 10px 18px rgba(37, 99, 235, 0.28);
+  pointer-events: none;
+  white-space: nowrap;
+}
+
+.slider-track[data-value]::after {
+  content: attr(data-value);
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+}
 #toolbar {
   padding-bottom: var(--space-3);
   margin-bottom: var(--space-4);

--- a/src/ui/leftPanel.js
+++ b/src/ui/leftPanel.js
@@ -24,41 +24,105 @@ export function initLeftPanel({ mount, store, onManualChange }) {
   container.className = "left-panel";
   container.innerHTML = `
     <section class="panel panel-compact">
-      <h3>Paramètres rapides</h3>
-      <div class="preset-buttons" data-role="presets"></div>
+      <div class="quick-card" data-card="presets">
+        <div class="quick-card-header">
+          <span class="quick-card-icon" aria-hidden="true">📍</span>
+          <div>
+            <h3>Paramètres rapides</h3>
+            <p class="quick-card-copy">Sélectionnez un préréglage pour charger immédiatement les coordonnées d'une ville.</p>
+          </div>
+        </div>
+        <div class="preset-grid" data-role="presets"></div>
+      </div>
     </section>
     <section class="panel panel-compact">
-      <h3>Jour de l'année</h3>
-      <label class="slider-label-legend">Jour sélectionné : <span data-label="date">21 mar</span></label>
-      <input type="range" min="1" max="365" step="1" data-input="day" />
-      <div class="slider-label"><span>1 Jan</span><span>31 Déc</span></div>
+      <div class="quick-card" data-card="day">
+        <div class="quick-card-header">
+          <span class="quick-card-icon" aria-hidden="true">🗓️</span>
+          <div>
+            <h3>Jour de l'année</h3>
+            <p class="quick-card-copy">Ajustez le calendrier pour explorer les variations saisonnières.</p>
+          </div>
+        </div>
+        <label class="slider-label-legend">Jour sélectionné : <span data-label="date">21 mar</span></label>
+        <div class="slider-track" data-slider="day">
+          <span class="value-pill" data-value-pill="day">21 mar</span>
+          <input type="range" min="1" max="365" step="1" data-input="day" />
+        </div>
+        <div class="slider-label"><span>1 Jan</span><span>31 Déc</span></div>
+      </div>
     </section>
     <section class="panel panel-compact">
-      <h3>Heure solaire</h3>
-      <label class="slider-label-legend">Heure sélectionnée : <span data-label="time">12:00</span></label>
-      <input type="range" min="0" max="23.5" step="0.5" data-input="time" />
-      <div class="slider-label"><span>00:00</span><span>23:30</span></div>
+      <div class="quick-card" data-card="time">
+        <div class="quick-card-header">
+          <span class="quick-card-icon" aria-hidden="true">⏱️</span>
+          <div>
+            <h3>Heure solaire</h3>
+            <p class="quick-card-copy">Régler l'heure permet de visualiser l'évolution de la lumière sur la journée.</p>
+          </div>
+        </div>
+        <label class="slider-label-legend">Heure sélectionnée : <span data-label="time">12:00</span></label>
+        <div class="slider-track" data-slider="time">
+          <span class="value-pill" data-value-pill="time">12:00</span>
+          <input type="range" min="0" max="23.5" step="0.5" data-input="time" />
+        </div>
+        <div class="slider-label"><span>00:00</span><span>23:30</span></div>
+      </div>
     </section>
   `;
   mount.appendChild(container);
 
   const presetHost = container.querySelector('[data-role="presets"]');
+  const presetButtons = new Map();
   PRESETS.forEach((preset) => {
     const btn = document.createElement("button");
     btn.type = "button";
-    btn.className = "preset-btn";
+    btn.className = "preset-chip";
     btn.textContent = preset.label;
+    btn.dataset.preset = preset.label;
     btn.addEventListener("click", () => {
       store.setMany({ latDeg: preset.lat, lonDeg: preset.lon });
       onManualChange?.("preset");
+      setActivePreset(preset.label);
     });
     presetHost.appendChild(btn);
+    presetButtons.set(preset.label, { btn, preset });
   });
 
   const daySlider = container.querySelector('[data-input="day"]');
   const timeSlider = container.querySelector('[data-input="time"]');
   const dateLabel = container.querySelector('[data-label="date"]');
   const timeLabel = container.querySelector('[data-label="time"]');
+  const dayValuePill = container.querySelector('[data-value-pill="day"]');
+  const timeValuePill = container.querySelector('[data-value-pill="time"]');
+
+  function setActivePreset(label) {
+    container.dataset.activePreset = label || "";
+    presetButtons.forEach(({ btn }, name) => {
+      if (name === label) {
+        btn.classList.add("is-active");
+        btn.setAttribute("aria-pressed", "true");
+      } else {
+        btn.classList.remove("is-active");
+        btn.setAttribute("aria-pressed", "false");
+      }
+    });
+  }
+
+  function positionValuePill(slider, pill) {
+    if (!slider || !pill) return;
+    const min = Number(slider.min);
+    const max = Number(slider.max);
+    const value = Number(slider.value);
+    const percent = max - min === 0 ? 0 : (value - min) / (max - min);
+    const clamped = Math.min(Math.max(percent * 100, 0), 100);
+    pill.style.setProperty("--value-progress", `${clamped}%`);
+    const track = slider.closest(".slider-track");
+    if (track) {
+      track.style.setProperty("--value-progress", `${clamped}%`);
+      track.dataset.value = slider.value;
+    }
+  }
 
   function updateFromState(snapshot) {
     if (snapshot.dayOfYear !== undefined) {
@@ -67,6 +131,10 @@ export function initLeftPanel({ mount, store, onManualChange }) {
         daySlider.value = String(dayValue);
       }
       dateLabel.textContent = formatDayOfYear(dayValue);
+      if (dayValuePill) {
+        dayValuePill.textContent = formatDayOfYear(dayValue);
+        positionValuePill(daySlider, dayValuePill);
+      }
     }
     if (snapshot.localTimeHours !== undefined) {
       const timeValue = Number(snapshot.localTimeHours);
@@ -74,16 +142,38 @@ export function initLeftPanel({ mount, store, onManualChange }) {
         timeSlider.value = String(timeValue);
       }
       timeLabel.textContent = formatTime(timeValue);
+      if (timeValuePill) {
+        timeValuePill.textContent = formatTime(timeValue);
+        positionValuePill(timeSlider, timeValuePill);
+      }
+    }
+
+    if (snapshot.latDeg !== undefined && snapshot.lonDeg !== undefined) {
+      const { latDeg, lonDeg } = snapshot;
+      const active = PRESETS.find(
+        (preset) =>
+          Math.abs(preset.lat - Number(latDeg)) < 1e-3 &&
+          Math.abs(preset.lon - Number(lonDeg)) < 1e-3
+      );
+      setActivePreset(active?.label || "");
     }
   }
 
   daySlider.addEventListener("input", () => {
     store.set("dayOfYear", Number(daySlider.value));
     onManualChange?.("day");
+    if (dayValuePill) {
+      dayValuePill.textContent = formatDayOfYear(Number(daySlider.value));
+      positionValuePill(daySlider, dayValuePill);
+    }
   });
   timeSlider.addEventListener("input", () => {
     store.set("localTimeHours", Number(timeSlider.value));
     onManualChange?.("time");
+    if (timeValuePill) {
+      timeValuePill.textContent = formatTime(Number(timeSlider.value));
+      positionValuePill(timeSlider, timeValuePill);
+    }
   });
 
   const unsubscribe = store.subscribe((_, snapshot) => {
@@ -92,10 +182,17 @@ export function initLeftPanel({ mount, store, onManualChange }) {
 
   updateFromState(store.getAll());
 
+  const handleResize = () => {
+    positionValuePill(daySlider, dayValuePill);
+    positionValuePill(timeSlider, timeValuePill);
+  };
+  window.addEventListener("resize", handleResize);
+
   return {
     destroy() {
       unsubscribe();
       mount.removeChild(container);
+      window.removeEventListener("resize", handleResize);
     },
   };
 }


### PR DESCRIPTION
## Summary
- wrap preset and slider controls in reusable quick-card sections with iconography and descriptions
- add active-state handling and slider value positioning for improved user feedback
- introduce elevated glassmorphism-inspired styles for cards, chips, and slider tracks

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d70ba27a148322aa0742349f926949